### PR TITLE
remove coverage dir from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 test/fixtures/compile-performance.js
+coverage


### PR DESCRIPTION
I wonder if the `coverage` directory is necessary to be included in the distribution package. I see it takes up around 3.5MB which contributes a lot to the package size.