### PR TITLE
Elminate quoted string array indexes. This improves obfuscation size.

### DIFF
--- a/src/node-transformers/obfuscating-transformers/obfuscating-replacers/literal-obfuscating-replacers/StringLiteralObfuscatingReplacer.ts
+++ b/src/node-transformers/obfuscating-transformers/obfuscating-replacers/literal-obfuscating-replacers/StringLiteralObfuscatingReplacer.ts
@@ -109,7 +109,7 @@ export class StringLiteralObfuscatingReplacer extends AbstractObfuscatingReplace
      * @returns {Literal}
      */
     private static getHexadecimalLiteralNode (hexadecimalIndex: string): ESTree.Literal {
-        const hexadecimalLiteralNode: ESTree.Literal = NodeFactory.literalNode(hexadecimalIndex);
+        const hexadecimalLiteralNode: ESTree.Literal = NodeFactory.literalNode(hexadecimalIndex, hexadecimalIndex);
 
         NodeMetadata.set(hexadecimalLiteralNode, { replacedLiteral: true });
 

--- a/test/functional-tests/javascript-obfuscator/JavaScriptObfuscator.spec.ts
+++ b/test/functional-tests/javascript-obfuscator/JavaScriptObfuscator.spec.ts
@@ -252,7 +252,7 @@ describe('JavaScriptObfuscator', () => {
 
             describe('Variant #4: with `stringArray`, `renameGlobals` and `identifiersPrefix` options', () => {
                 const stringArrayRegExp: RegExp = /^var foo_0x(\w){4} *= *\['abc'\];/;
-                const stringArrayCallRegExp: RegExp = /var *foo_0x(\w){4,6} *= *foo_0x(\w){4}\('0x0'\);$/;
+                const stringArrayCallRegExp: RegExp = /var *foo_0x(\w){4,6} *= *foo_0x(\w){4}\(0x0\);$/;
 
                 let obfuscatedCode: string;
 
@@ -344,7 +344,7 @@ describe('JavaScriptObfuscator', () => {
 
         describe('latin literal variable value', () => {
             const stringArrayLatinRegExp: RegExp = /^var _0x(\w){4} *= *\['abc'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *_0x(\w){4}\('0x0'\);$/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *_0x(\w){4}\(0x0\);$/;
 
             let obfuscatedCode: string;
 
@@ -372,7 +372,7 @@ describe('JavaScriptObfuscator', () => {
 
         describe('cyrillic literal variable value', () => {
             const stringArrayCyrillicRegExp: RegExp = /^var _0x(\w){4} *= *\['абц'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *_0x(\w){4}\('0x0'\);$/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *_0x(\w){4}\(0x0\);$/;
 
             let obfuscatedCode: string;
 

--- a/test/functional-tests/node-transformers/converting-transformers/member-expression-transformer/MemberExpressionTransformer.spec.ts
+++ b/test/functional-tests/node-transformers/converting-transformers/member-expression-transformer/MemberExpressionTransformer.spec.ts
@@ -31,7 +31,7 @@ describe('MemberExpressionTransformer', () => {
 
         describe('`stringArray` option is enabled', () => {
             const stringArrayRegExp: RegExp = /var *_0x([a-f0-9]){4} *= *\['log'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *console\[_0x([a-f0-9]){4}\('0x0'\)\];/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *console\[_0x([a-f0-9]){4}\(0x0\)\];/;
 
             let obfuscatedCode: string;
 
@@ -61,7 +61,7 @@ describe('MemberExpressionTransformer', () => {
     describe('transformation of member expression node with square brackets', () => {
         describe('Variant #1: square brackets literal ', () => {
             const stringArrayRegExp: RegExp = /var *_0x([a-f0-9]){4} *= *\['log'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *console\[_0x([a-f0-9]){4}\('0x0'\)\];/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *console\[_0x([a-f0-9]){4}\(0x0\)\];/;
 
             let obfuscatedCode: string;
 

--- a/test/functional-tests/node-transformers/converting-transformers/method-definition-transformer/MethodDefinitionTransformer.spec.ts
+++ b/test/functional-tests/node-transformers/converting-transformers/method-definition-transformer/MethodDefinitionTransformer.spec.ts
@@ -30,7 +30,7 @@ describe('MethodDefinitionTransformer', () => {
 
     describe('Variant #2: `stringArray` option is enabled', () => {
         const stringArrayRegExp: RegExp = /var *_0x([a-f0-9]){4} *= *\['bar'\];/;
-        const stringArrayCallRegExp: RegExp = /\[_0x([a-f0-9]){4}\('0x0'\)\]\(\)\{\}/;
+        const stringArrayCallRegExp: RegExp = /\[_0x([a-f0-9]){4}\(0x0\)\]\(\)\{\}/;
 
         let obfuscatedCode: string;
 

--- a/test/functional-tests/node-transformers/converting-transformers/object-expression-keys-transformer/ObjectExpressionKeysTransformer.spec.ts
+++ b/test/functional-tests/node-transformers/converting-transformers/object-expression-keys-transformer/ObjectExpressionKeysTransformer.spec.ts
@@ -119,7 +119,7 @@ describe('ObjectExpressionKeysTransformer', () => {
                         ...NO_ADDITIONAL_NODES_PRESET,
                         controlFlowFlattening: true,
                         controlFlowFlatteningThreshold: 1,
-                        transformObjectKeys: true
+                        transformObjectKeys: true                        
                     }
                 ).getObfuscatedCode();
             });

--- a/test/functional-tests/node-transformers/dead-code-injection-transformers/DeadCodeInjectionTransformer.spec.ts
+++ b/test/functional-tests/node-transformers/dead-code-injection-transformers/DeadCodeInjectionTransformer.spec.ts
@@ -18,10 +18,10 @@ describe('DeadCodeInjectionTransformer', () => {
 
         describe('Variant #1 - 5 simple block statements', () => {
             const regExp: RegExp = new RegExp(
-                `if *\\(${variableMatch}\\('${hexMatch}'\\) *[=|!]== *${variableMatch}\\('${hexMatch}'\\)\\) *\\{`+
-                    `(?:console|${variableMatch})\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                `if *\\(${variableMatch}\\(${hexMatch}\\) *[=|!]== *${variableMatch}\\(${hexMatch}\\)\\) *\\{`+
+                    `(?:console|${variableMatch})\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                 `\\} *else *\\{`+
-                    `(?:console|${variableMatch})\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                    `(?:console|${variableMatch})\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                 `\\}`,
                 'g'
             );
@@ -57,7 +57,7 @@ describe('DeadCodeInjectionTransformer', () => {
         describe('Variant #2 - block statements count is less than `5`', () => {
             const regexp: RegExp = new RegExp(
                 `var *${variableMatch} *= *function *\\(\\) *\\{` +
-                    `console\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                    `console\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                 `\\};`,
                 'g'
             );
@@ -93,7 +93,7 @@ describe('DeadCodeInjectionTransformer', () => {
         describe('Variant #3 - deadCodeInjectionThreshold: 0', () => {
             const regexp: RegExp = new RegExp(
                 `var *${variableMatch} *= *function *\\(\\) *\\{` +
-                    `console\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                    `console\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                 `\\};`,
                 'g'
             );
@@ -130,7 +130,7 @@ describe('DeadCodeInjectionTransformer', () => {
             describe('Variant #1', () => {
                 const functionRegExp: RegExp = new RegExp(
                     `var *${variableMatch} *= *function *\\(\\) *\\{` +
-                        `console\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                        `console\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                     `\\};`,
                     'g'
                 );
@@ -183,7 +183,7 @@ describe('DeadCodeInjectionTransformer', () => {
             describe('Variant #2', () => {
                 const functionRegExp: RegExp = new RegExp(
                     `var *${variableMatch} *= *function *\\(\\) *\\{` +
-                        `console\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                        `console\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                     `\\};`,
                     'g'
                 );
@@ -236,7 +236,7 @@ describe('DeadCodeInjectionTransformer', () => {
         describe('Variant #5 - await expression in block statement', () => {
             const functionRegExp: RegExp = new RegExp(
                 `var *${variableMatch} *= *function *\\(\\) *\\{` +
-                    `console\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                    `console\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                 `\\};`,
                 'g'
             );
@@ -287,7 +287,7 @@ describe('DeadCodeInjectionTransformer', () => {
         describe('Variant #6 - super expression in block statement', () => {
             const functionRegExp: RegExp = new RegExp(
                 `var *${variableMatch} *= *function *\\(\\) *\\{` +
-                    `console\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                    `console\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                 `\\};`,
                 'g'
             );
@@ -344,28 +344,28 @@ describe('DeadCodeInjectionTransformer', () => {
             const functionMatch: string = `var *${variableMatch} *= *function *\\(\\) *\\{`;
 
             const match1: string = `` +
-                `if *\\(${variableMatch}\\('${hexMatch}'\\) *=== *${variableMatch}\\('${hexMatch}'\\)\\) *\\{` +
+                `if *\\(${variableMatch}\\(${hexMatch}\\) *=== *${variableMatch}\\(${hexMatch}\\)\\) *\\{` +
                     `console.*` +
                 `\\} *else *\\{` +
                     `alert.*` +
                 `\\}` +
             ``;
             const match2: string = `` +
-                `if *\\(${variableMatch}\\('${hexMatch}'\\) *!== *${variableMatch}\\('${hexMatch}'\\)\\) *\\{` +
+                `if *\\(${variableMatch}\\(${hexMatch}\\) *!== *${variableMatch}\\(${hexMatch}\\)\\) *\\{` +
                     `console.*` +
                 `\\} *else *\\{` +
                     `alert.*` +
                 `\\}` +
             ``;
             const match3: string = `` +
-                `if *\\(${variableMatch}\\('${hexMatch}'\\) *=== *${variableMatch}\\('${hexMatch}'\\)\\) *\\{` +
+                `if *\\(${variableMatch}\\(${hexMatch}\\) *=== *${variableMatch}\\(${hexMatch}\\)\\) *\\{` +
                     `alert.*` +
                 `\\} *else *\\{` +
                     `console.*` +
                 `\\}` +
             ``;
             const match4: string = `` +
-                `if *\\(${variableMatch}\\('${hexMatch}'\\) *!== *${variableMatch}\\('${hexMatch}'\\)\\) *\\{` +
+                `if *\\(${variableMatch}\\(${hexMatch}\\) *!== *${variableMatch}\\(${hexMatch}\\)\\) *\\{` +
                     `alert.*` +
                 `\\} *else *\\{` +
                     `console.*` +
@@ -440,7 +440,7 @@ describe('DeadCodeInjectionTransformer', () => {
         describe('Variant #8 - block scope of block statement is `ProgramNode`', () => {
             const regExp: RegExp = new RegExp(
                 `if *\\(!!\\[\\]\\) *{` +
-                    `console\\[${variableMatch}\\('${hexMatch}'\\)\\]\\(${variableMatch}\\('${hexMatch}'\\)\\);` +
+                    `console\\[${variableMatch}\\(${hexMatch}\\)\\]\\(${variableMatch}\\(${hexMatch}\\)\\);` +
                 `\\}`
             );
 

--- a/test/functional-tests/node-transformers/obfuscating-transformers/literal-transformer/LiteralTransformer.spec.ts
+++ b/test/functional-tests/node-transformers/obfuscating-transformers/literal-transformer/LiteralTransformer.spec.ts
@@ -13,7 +13,7 @@ describe('LiteralTransformer', () => {
     describe('transformation of literal node with string value', () => {
         describe('Variant #1: default behaviour', () => {
             const stringArrayRegExp: RegExp = /^var *_0x([a-f0-9]){4} *= *\['test'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\('0x0'\);/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\(0x0\);/;
 
             let obfuscatedCode: string;
 
@@ -83,7 +83,7 @@ describe('LiteralTransformer', () => {
 
         describe('Variant #4: same literal node values', () => {
             const stringArrayRegExp: RegExp = /^var *_0x([a-f0-9]){4} *= *\['test'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\('0x0'\);/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\(0x0\);/;
 
             let obfuscatedCode: string;
 
@@ -134,7 +134,7 @@ describe('LiteralTransformer', () => {
 
         describe('Variant #6: `unicodeEscapeSequence` and `stringArray` options are enabled', () => {
             const stringArrayRegExp: RegExp = /^var *_0x([a-f0-9]){4} *= *\['\\x74\\x65\\x73\\x74'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\('0x0'\);/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\(0x0\);/;
 
             let obfuscatedCode: string;
 
@@ -186,7 +186,7 @@ describe('LiteralTransformer', () => {
 
         describe('Variant #8: base64 encoding', () => {
             const stringArrayRegExp: RegExp = /^var *_0x([a-f0-9]){4} *= *\['dGVzdA=='\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\('0x0'\);/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\(0x0\);/;
 
             let obfuscatedCode: string;
 
@@ -214,7 +214,7 @@ describe('LiteralTransformer', () => {
         });
 
         describe('Variant #9: rc4 encoding', () => {
-            const regExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\('0x0', *'.{4}'\);/;
+            const regExp: RegExp = /var *test *= *_0x([a-f0-9]){4}\(0x0, *'.{4}'\);/;
 
             let obfuscatedCode: string;
 
@@ -242,7 +242,7 @@ describe('LiteralTransformer', () => {
             const stringArrayThreshold: number = 0.5;
             const delta: number = 0.1;
 
-            const regExp1: RegExp = /var *test *= *_0x([a-f0-9]){4}\('0x0'\);/g;
+            const regExp1: RegExp = /var *test *= *_0x([a-f0-9]){4}\(0x0\);/g;
             const regExp2: RegExp = /var *test *= *'test';/g;
 
             let stringArrayProbability: number,
@@ -281,7 +281,7 @@ describe('LiteralTransformer', () => {
         });
 
         describe('Variant #11: string array calls wrapper name', () => {
-            const regExp: RegExp = /console\[b\('0x0'\)]\('a'\);/;
+            const regExp: RegExp = /console\[b\(0x0\)]\('a'\);/;
 
             let obfuscatedCode: string;
 
@@ -308,7 +308,7 @@ describe('LiteralTransformer', () => {
             describe('Variant #1: base `reservedStrings` values', () => {
                 describe('Variant #1: single reserved string value', () => {
                     const stringLiteralRegExp1: RegExp = /const foo *= *'foo';/;
-                    const stringLiteralRegExp2: RegExp = /const bar *= *_0x([a-f0-9]){4}\('0x0'\);/;
+                    const stringLiteralRegExp2: RegExp = /const bar *= *_0x([a-f0-9]){4}\(0x0\);/;
 
                     let obfuscatedCode: string;
 
@@ -367,7 +367,7 @@ describe('LiteralTransformer', () => {
 
             describe('Variant #2: RegExp `reservedStrings` values', () => {
                 describe('Variant #1: single reserved string value', () => {
-                    const stringLiteralRegExp1: RegExp = /const foo *= *_0x([a-f0-9]){4}\('0x0'\);/;
+                    const stringLiteralRegExp1: RegExp = /const foo *= *_0x([a-f0-9]){4}\(0x0\);/;
                     const stringLiteralRegExp2: RegExp = /const bar *= *'bar';/;
 
                     let obfuscatedCode: string;

--- a/test/functional-tests/node-transformers/preparing-transformers/obfuscating-guards/black-list-obfuscating-guard/BlackListObfuscatingGuard.spec.ts
+++ b/test/functional-tests/node-transformers/preparing-transformers/obfuscating-guards/black-list-obfuscating-guard/BlackListObfuscatingGuard.spec.ts
@@ -11,7 +11,7 @@ describe('BlackListObfuscatingGuard', () => {
         describe('`\'use strict\';` operator', () => {
             const useStrictOperatorRegExp: RegExp = /'use *strict';/;
             const stringArrayLatinRegExp: RegExp = /var _0x(\w){4} *= *\['abc'\];/;
-            const stringArrayCallRegExp: RegExp = /var *test *= *_0x(\w){4}\('0x0'\);$/;
+            const stringArrayCallRegExp: RegExp = /var *test *= *_0x(\w){4}\(0x0\);$/;
 
             let obfuscatedCode: string;
 


### PR DESCRIPTION
Currently string array calls are generated like this: 

```
console.log("Hello World!")  => console.log(b('0x23'))
```

This change would result in the following output which removes the unnecessary quotes.

```
console.log("Hello World!")  => console.log(b(0x23))
```
