### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Following options are available for the JS Obfuscator:
     splitStrings: false,
     splitStringsChunkLength: 10,
     stringArray: true,
-    stringArrayCallsIndexType: [
+    stringArrayIndexesType: [
         'hexadecimal-number'
     ],
     stringArrayEncoding: [],


### PR DESCRIPTION
in readme I found option `stringArrayCallsIndexType`, but if I change this option I didn't get any changes.
After check docs I saw what docs have another option `stringArrayIndexesType`. 
So, suppouse, I should replace this? :eyes: