### PR TITLE
make forward slash in output path consistent

### DIFF
--- a/src/cli/utils/ObfuscatedCodeFileUtils.ts
+++ b/src/cli/utils/ObfuscatedCodeFileUtils.ts
@@ -61,6 +61,12 @@ export class ObfuscatedCodeFileUtils {
         if (isDirectoryRawInputPath) {
             if (isDirectoryRawOutputPath) {
                 const parsedNormalizedFilePath: path.ParsedPath = path.parse(normalizedFilePath);
+
+                // Make ending with "/" consistent
+                if (!parsedNormalizedFilePath.dir.endsWith('/') && this.inputPath.endsWith('/')) {
+                    parsedNormalizedFilePath.dir += '/';
+                }
+
                 const baseOutputPath: string = path.join(
                     parsedNormalizedFilePath.dir.replace(this.inputPath, ''),
                     parsedNormalizedFilePath.base

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -48,6 +48,7 @@ import './unit-tests/utils/CryptUtilsStringArray.spec';
 import './unit-tests/utils/EscapeSequenceEncoder.spec';
 import './unit-tests/utils/LevelledTopologicalSorter.spec';
 import './unit-tests/utils/NumberUtils.spec';
+import './unit-tests/utils/ObfuscatedCodeFileUtils.spec'
 import './unit-tests/utils/RandomGenerator.spec';
 import './unit-tests/utils/StringUtils.spec';
 import './unit-tests/utils/Utils.spec';

--- a/test/unit-tests/utils/ObfuscatedCodeFileUtils.spec.ts
+++ b/test/unit-tests/utils/ObfuscatedCodeFileUtils.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { ObfuscatedCodeFileUtils } from '../../../src/cli/utils/ObfuscatedCodeFileUtils';
+
+describe('ObfuscatedCodeFileUtils', () => {
+  let util: ObfuscatedCodeFileUtils;
+
+  beforeEach(() => {
+    util = new ObfuscatedCodeFileUtils('src/cli/', {
+      output: 'src/cli/dist',
+    });
+  });
+
+  it('should handle input path ending (or not ending) with forward slash', () => {
+    const result = util.getOutputCodePath('src/cli/app.js');
+    expect(result).equals('src/cli/dist/app.js');
+  });
+});


### PR DESCRIPTION
Noticed that a trailing forward slash (or lack thereof?) on an output directory can cause funny results for output names.

Example without this change (from my unit test):

You're trying to obfuscate the code in `src/cli/` and output it to `src/cli/dist` but some of the files end up in `src/cli/dist/src/cli/` instead.