### PR TITLE
Added test to for resolvedNames bug in classes

### DIFF
--- a/test/functional-tests/javascript-obfuscator/JavaScriptObfuscator.spec.ts
+++ b/test/functional-tests/javascript-obfuscator/JavaScriptObfuscator.spec.ts
@@ -95,6 +95,41 @@ describe('JavaScriptObfuscator', () => {
                 });
             });
 
+            describe('class function not obfuscated if option "reservedNames', () => {
+                let obfuscations: string[];
+
+                beforeEach(() => {
+                    obfuscations = []
+                    const code: string = readFileAsString(__dirname + '/fixtures/class-with-function.js');
+                    for (let i = 0; i < 100; i++) {
+                        const obfuscatedCode:string = JavaScriptObfuscator.obfuscate(
+                            code,
+                            {
+                                controlFlowFlattening: true,
+                                deadCodeInjection: true,
+                                reservedNames: ['bar']
+                            }
+                        ).getObfuscatedCode();
+
+                        obfuscations.push(obfuscatedCode)
+                    }
+                });
+
+                it('class should always have "bar" function not obfuscated', () => {
+                    let obfuscated: number = 0;
+                    let notObfuscated: number = 0;
+                    for (const codeAsString of obfuscations) {
+                        if (codeAsString.includes("['bar']")) { notObfuscated++; }
+                        else { obfuscated++; }
+
+                    }
+
+                    console.log({obfuscated, notObfuscated})
+                    assert.equal(obfuscated, 0)
+                    assert.equal(notObfuscated, obfuscations.length)
+                });
+            });
+
             describe('invalid source code type', () => {
                 let obfuscatedCode: string;
 

--- a/test/functional-tests/javascript-obfuscator/fixtures/class-with-function.js
+++ b/test/functional-tests/javascript-obfuscator/fixtures/class-with-function.js
@@ -1,0 +1,6 @@
+class Foo{
+    bar(){
+        console.log(1)
+        baz()
+    }
+}


### PR DESCRIPTION
**Use case**
I want to obfuscate a class, but I need one function name not to be obfuscated.
I specify the name of the function in 'resolvedNames'

**Expected**
No matter how many times I perform the obfuscation, I am expecting the function name never to be obfuscated

**Results**
Running the test several times, I can see that the results are never consistent, and most of the time the behaviour is not the expected

---

Unfortunately I am not good with TypeScript so I was not able to provide a fix, but I was able to add a test case as a PoC of the bug.

Hope this was helpful