### PR TITLE
fix: .mjs and .cjs in availableInputExtensions

### DIFF
--- a/src/cli/JavaScriptObfuscatorCLI.ts
+++ b/src/cli/JavaScriptObfuscatorCLI.ts
@@ -40,7 +40,9 @@ export class JavaScriptObfuscatorCLI implements IInitializable {
      * @type {string[]}
      */
     public static readonly availableInputExtensions: string[] = [
-        '.js'
+        '.js',
+        '.mjs',
+        '.cjs'
     ];
 
     /**


### PR DESCRIPTION
Hi!
I saw https://github.com/javascript-obfuscator/javascript-obfuscator/pull/1059 PR

However javascript-obfuscator still doesn't support `.mjs` and `.cjs` extensions when running in CLI mode. I fixed it by adding these extensions into `availableInputExtensions` array