### PR TITLE
feat: add numbersToHexadecimal option to control number to hex conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ Following options are available for the JS Obfuscator:
     inputFileName: '',
     log: false,
     numbersToExpressions: false,
+    numbersToHexadecimal: true,
     optionsPreset: 'default',
     renameGlobals: false,
     renameProperties: false,
@@ -634,6 +635,7 @@ Following options are available for the JS Obfuscator:
     --ignore-imports <boolean>
     --log <boolean>
     --numbers-to-expressions <boolean>
+    --numbers-to-hexadecimal <boolean>
     --options-preset <string> [default, low-obfuscation, medium-obfuscation, high-obfuscation]
     --rename-globals <boolean>
     --rename-properties <boolean>
@@ -1099,13 +1101,33 @@ Type: `boolean` Default: `false`
 
 Enables numbers conversion to expressions
 
-Example: 
+Example:
 ```ts
 // input
 const foo = 1234;
 
 // output
 const foo=-0xd93+-0x10b4+0x41*0x67+0x84e*0x3+-0xff8;
+```
+
+### `numbersToHexadecimal`
+Type: `boolean` Default: `true`
+
+Enables conversion of integer numbers to hexadecimal format.
+
+When `true`, integer numbers like `1000` will be converted to `0x3e8`.
+When `false`, numbers remain in their original decimal format.
+
+Example:
+```ts
+// input
+setInterval(sendHeartbeat, 1000 * 60 * 1);
+
+// output with numbersToHexadecimal: true
+setInterval(sendHeartbeat, 0x3e8 * 0x3c * 0x1);
+
+// output with numbersToHexadecimal: false
+setInterval(sendHeartbeat, 1000 * 60 * 1);
 ```
 
 ### `optionsPreset`

--- a/src/cli/JavaScriptObfuscatorCLI.ts
+++ b/src/cli/JavaScriptObfuscatorCLI.ts
@@ -262,6 +262,10 @@ export class JavaScriptObfuscatorCLI implements IInitializable {
             .option('--log <boolean>', 'Enables logging of the information to the console', BooleanSanitizer)
             .option('--numbers-to-expressions <boolean>', 'Enables numbers conversion to expressions', BooleanSanitizer)
             .option(
+                '--numbers-to-hexadecimal <boolean>', 'Enables conversion of integer numbers to hexadecimal format',
+                BooleanSanitizer
+            )
+            .option(
                 '--options-preset <string>',
                 'Allows to set options preset. ' +
                     `Values: ${CLIUtils.stringifyOptionAvailableValues(OptionsPreset)}. ` +

--- a/src/custom-code-helpers/CustomCodeHelperObfuscator.ts
+++ b/src/custom-code-helpers/CustomCodeHelperObfuscator.ts
@@ -46,6 +46,7 @@ export class CustomCodeHelperObfuscator implements ICustomCodeHelperObfuscator {
             identifierNamesGenerator: this.options.identifierNamesGenerator,
             identifiersDictionary: this.options.identifiersDictionary,
             numbersToExpressions: this.options.numbersToExpressions,
+            numbersToHexadecimal: this.options.numbersToHexadecimal,
             simplify: this.options.simplify,
             seed: this.randomGenerator.getRawSeed(),
             ...additionalOptions

--- a/src/interfaces/options/IOptions.ts
+++ b/src/interfaces/options/IOptions.ts
@@ -31,6 +31,7 @@ export interface IOptions {
     readonly inputFileName: string;
     readonly log: boolean;
     readonly numbersToExpressions: boolean;
+    readonly numbersToHexadecimal: boolean;
     readonly optionsPreset: TOptionsPreset;
     readonly renameGlobals: boolean;
     readonly renameProperties: boolean;

--- a/src/node-transformers/converting-transformers/NumberLiteralTransformer.ts
+++ b/src/node-transformers/converting-transformers/NumberLiteralTransformer.ts
@@ -85,7 +85,7 @@ export class NumberLiteralTransformer extends AbstractNodeTransformer {
         if (this.numberLiteralCache.has(literalValue)) {
             rawValue = <string>this.numberLiteralCache.get(literalValue);
         } else {
-            if (NumberUtils.isCeil(literalValue)) {
+            if (this.options.numbersToHexadecimal && NumberUtils.isCeil(literalValue)) {
                 rawValue = NumberUtils.toHex(literalValue);
             } else {
                 rawValue = String(literalValue);

--- a/src/options/Options.ts
+++ b/src/options/Options.ts
@@ -211,6 +211,12 @@ export class Options implements IOptions {
     public readonly numbersToExpressions!: boolean;
 
     /**
+     * @type {boolean}
+     */
+    @IsBoolean()
+    public readonly numbersToHexadecimal!: boolean;
+
+    /**
      * @type {TOptionsPreset}
      */
     @IsIn([

--- a/src/options/presets/Default.ts
+++ b/src/options/presets/Default.ts
@@ -32,6 +32,7 @@ export const DEFAULT_PRESET: TInputOptions = Object.freeze({
     inputFileName: '',
     log: false,
     numbersToExpressions: false,
+    numbersToHexadecimal: true,
     optionsPreset: OptionsPreset.Default,
     renameGlobals: false,
     renameProperties: false,

--- a/src/options/presets/NoCustomNodes.ts
+++ b/src/options/presets/NoCustomNodes.ts
@@ -29,6 +29,7 @@ export const NO_ADDITIONAL_NODES_PRESET: TInputOptions = Object.freeze({
     inputFileName: '',
     log: false,
     numbersToExpressions: false,
+    numbersToHexadecimal: true,
     renameGlobals: false,
     renameProperties: false,
     renamePropertiesMode: RenamePropertiesMode.Safe,

--- a/test/functional-tests/node-transformers/converting-transformers/number-literal-transformer/NumberLiteralTransformer.spec.ts
+++ b/test/functional-tests/node-transformers/converting-transformers/number-literal-transformer/NumberLiteralTransformer.spec.ts
@@ -46,4 +46,52 @@ describe('NumberLiteralTransformer', () => {
             assert.match(obfuscatedCode, regExp);
         });
     });
+
+    describe('numbersToHexadecimal option', () => {
+        describe('when numbersToHexadecimal is true (default)', () => {
+            const regExp: RegExp = /^setInterval\(sendHeartbeat, 0x3e8 \* 0x3c \* 0x1\);$/;
+
+            let obfuscatedCode: string;
+
+            before(() => {
+                const code: string = 'setInterval(sendHeartbeat, 1000 * 60 * 1);';
+
+                obfuscatedCode = JavaScriptObfuscator.obfuscate(
+                    code,
+                    {
+                        ...NO_ADDITIONAL_NODES_PRESET,
+                        numbersToHexadecimal: true,
+                        compact: false
+                    }
+                ).getObfuscatedCode();
+            });
+
+            it('should convert numbers to hexadecimal', () => {
+                assert.match(obfuscatedCode, regExp);
+            });
+        });
+
+        describe('when numbersToHexadecimal is false', () => {
+            const regExp: RegExp = /^setInterval\(sendHeartbeat, 1000 \* 60 \* 1\);$/;
+
+            let obfuscatedCode: string;
+
+            before(() => {
+                const code: string = 'setInterval(sendHeartbeat, 1000 * 60 * 1);';
+
+                obfuscatedCode = JavaScriptObfuscator.obfuscate(
+                    code,
+                    {
+                        ...NO_ADDITIONAL_NODES_PRESET,
+                        numbersToHexadecimal: false,
+                        compact: false
+                    }
+                ).getObfuscatedCode();
+            });
+
+            it('should keep numbers in decimal format', () => {
+                assert.match(obfuscatedCode, regExp);
+            });
+        });
+    });
 });


### PR DESCRIPTION
## 🎯 Purpose
Resolves #1317 - Adds option to prevent automatic conversion of numbers to hexadecimal format.

## 📋 Changes
- ✅ Added `numbersToHexadecimal` boolean option (default: `true`)
- ✅ Updated `NumberLiteralTransformer` to respect the new option
- ✅ Added CLI support with `--numbers-to-hexadecimal` flag
- ✅ Updated all configuration presets and interfaces
- ✅ Added comprehensive test coverage
- ✅ Updated README documentation with examples

## 🔄 Behavior
- **Default (`true`)**: Maintains existing behavior (backward compatible)
- **New (`false`)**: Keeps numbers in decimal format

## 🧪 Testing
Added test cases covering both scenarios:
- ✅ `numbersToHexadecimal: true` converts to hex
- ✅ `numbersToHexadecimal: false` preserves decimal

## 📚 Documentation
- Updated README with option description and examples
- Added CLI option documentation
- Updated default options section

## 🔧 Usage Examples
```javascript
// JavaScript API
JavaScriptObfuscator.obfuscate(code, {
    numbersToHexadecimal: false
});

// CLI
javascript-obfuscator input.js --numbers-to-hexadecimal false
```
```

This solution will help not just @acemtp, but any other users who prefer to keep their numbers in decimal format for readability or specific requirements!
