### PR TITLE
Inversify v7 migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@
 - **Parser**: Acorn 8.8.2 (ES3-ES2020 support)
 - **Code Generator**: @javascript-obfuscator/escodegen 2.3.0
 - **AST Traversal**: @javascript-obfuscator/estraverse 5.4.0
-- **DI Framework**: InversifyJS 6.0.1
+- **DI Framework**: InversifyJS 7.10.8
 - **Testing**: Mocha 10.4.0 + Chai 4.3.7
 - **Build System**: Webpack 5.75.0
 
@@ -210,7 +210,7 @@ The obfuscation process follows a multi-stage pipeline defined in `JavaScriptObf
 
 ### Dependency Injection Architecture
 
-The project uses **InversifyJS** for dependency injection, providing:
+The project uses **InversifyJS v7** for dependency injection, providing:
 
 - **Modularity**: Clean separation of concerns
 - **Testability**: Easy mocking and testing
@@ -218,6 +218,13 @@ The project uses **InversifyJS** for dependency injection, providing:
 - **Scalability**: Easy addition of new transformers
 
 All components are registered in container modules located in `src/container/modules/`.
+
+**Key Changes in InversifyJS v7:**
+- Container modules now use `ContainerModuleLoadOptions` instead of separate `bind`, `unbind`, etc. parameters
+- `getNamed`, `getTagged`, etc. are replaced by `get(serviceId, { name: ... })` or `get(serviceId, { tag: ... })`
+- `load()` and `unload()` are now async, with `loadSync()` and `unloadSync()` alternatives for synchronous operations
+- Types like `Context`, `Newable`, `Factory` are now directly exported instead of through `interfaces` namespace
+- Custom metadata and middleware features have been removed
 
 ## Key Components Deep Dive
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-scope": "8.4.0",
     "eslint-visitor-keys": "4.2.1",
     "fast-deep-equal": "3.1.3",
-    "inversify": "6.1.4",
+    "inversify": "7.11.0",
     "js-string-escape": "1.0.1",
     "md5": "2.3.0",
     "multimatch": "5.0.0",

--- a/src/analyzers/calls-graph-analyzer/callee-data-extractors/FunctionDeclarationCalleeDataExtractor.ts
+++ b/src/analyzers/calls-graph-analyzer/callee-data-extractors/FunctionDeclarationCalleeDataExtractor.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { injectable, injectFromBase } from 'inversify';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
 import * as ESTree from 'estree';
@@ -9,6 +9,7 @@ import { AbstractCalleeDataExtractor } from './AbstractCalleeDataExtractor';
 import { NodeGuards } from '../../../node/NodeGuards';
 import { NodeStatementUtils } from '../../../node/NodeStatementUtils';
 
+@injectFromBase()
 @injectable()
 export class FunctionDeclarationCalleeDataExtractor extends AbstractCalleeDataExtractor {
     /**

--- a/src/analyzers/calls-graph-analyzer/callee-data-extractors/FunctionExpressionCalleeDataExtractor.ts
+++ b/src/analyzers/calls-graph-analyzer/callee-data-extractors/FunctionExpressionCalleeDataExtractor.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { injectable, injectFromBase } from 'inversify';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
 import * as ESTree from 'estree';
@@ -9,6 +9,7 @@ import { AbstractCalleeDataExtractor } from './AbstractCalleeDataExtractor';
 import { NodeGuards } from '../../../node/NodeGuards';
 import { NodeStatementUtils } from '../../../node/NodeStatementUtils';
 
+@injectFromBase()
 @injectable()
 export class FunctionExpressionCalleeDataExtractor extends AbstractCalleeDataExtractor {
     /**

--- a/src/analyzers/calls-graph-analyzer/callee-data-extractors/ObjectExpressionCalleeDataExtractor.ts
+++ b/src/analyzers/calls-graph-analyzer/callee-data-extractors/ObjectExpressionCalleeDataExtractor.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { injectable, injectFromBase } from 'inversify';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
 import * as ESTree from 'estree';
@@ -11,6 +11,7 @@ import { AbstractCalleeDataExtractor } from './AbstractCalleeDataExtractor';
 import { NodeGuards } from '../../../node/NodeGuards';
 import { NodeStatementUtils } from '../../../node/NodeStatementUtils';
 
+@injectFromBase()
 @injectable()
 export class ObjectExpressionCalleeDataExtractor extends AbstractCalleeDataExtractor {
     /**

--- a/src/code-transformers/CodeTransformerNamesGroupsBuilder.ts
+++ b/src/code-transformers/CodeTransformerNamesGroupsBuilder.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { injectable, injectFromBase } from 'inversify';
 
 import { ICodeTransformer } from '../interfaces/code-transformers/ICodeTransformer';
 
@@ -6,6 +6,7 @@ import { CodeTransformer } from '../enums/code-transformers/CodeTransformer';
 
 import { AbstractTransformerNamesGroupsBuilder } from '../utils/AbstractTransformerNamesGroupsBuilder';
 
+@injectFromBase()
 @injectable()
 export class CodeTransformerNamesGroupsBuilder extends AbstractTransformerNamesGroupsBuilder<
     CodeTransformer,

--- a/src/code-transformers/preparing-transformers/HashbangOperatorTransformer.ts
+++ b/src/code-transformers/preparing-transformers/HashbangOperatorTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { IOptions } from '../../interfaces/options/IOptions';
@@ -8,6 +8,7 @@ import { CodeTransformationStage } from '../../enums/code-transformers/CodeTrans
 
 import { AbstractCodeTransformer } from '../AbstractCodeTransformer';
 
+@injectFromBase()
 @injectable()
 export class HashbangOperatorTransformer extends AbstractCodeTransformer {
     /**

--- a/src/container/modules/analyzers/AnalyzersModule.ts
+++ b/src/container/modules/analyzers/AnalyzersModule.ts
@@ -1,5 +1,5 @@
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { ICalleeDataExtractor } from '../../../interfaces/analyzers/calls-graph-analyzer/ICalleeDataExtractor';
@@ -19,48 +19,53 @@ import { PrevailingKindOfVariablesAnalyzer } from '../../../analyzers/prevailing
 import { ScopeAnalyzer } from '../../../analyzers/scope-analyzer/ScopeAnalyzer';
 import { StringArrayStorageAnalyzer } from '../../../analyzers/string-array-storage-analyzer/StringArrayStorageAnalyzer';
 
-export const analyzersModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const analyzersModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // calls graph analyzer
-    bind<ICallsGraphAnalyzer>(ServiceIdentifiers.ICallsGraphAnalyzer).to(CallsGraphAnalyzer).inSingletonScope();
+    options.bind<ICallsGraphAnalyzer>(ServiceIdentifiers.ICallsGraphAnalyzer).to(CallsGraphAnalyzer).inSingletonScope();
 
     // number numerical expression analyzer
-    bind<INumberNumericalExpressionAnalyzer>(ServiceIdentifiers.INumberNumericalExpressionAnalyzer)
+    options
+        .bind<INumberNumericalExpressionAnalyzer>(ServiceIdentifiers.INumberNumericalExpressionAnalyzer)
         .to(NumberNumericalExpressionAnalyzer)
         .inSingletonScope();
 
     // prevailing kind of variables analyzer
-    bind<IPrevailingKindOfVariablesAnalyzer>(ServiceIdentifiers.IPrevailingKindOfVariablesAnalyzer)
+    options
+        .bind<IPrevailingKindOfVariablesAnalyzer>(ServiceIdentifiers.IPrevailingKindOfVariablesAnalyzer)
         .to(PrevailingKindOfVariablesAnalyzer)
         .inSingletonScope();
 
     // scope analyzer
-    bind<IScopeAnalyzer>(ServiceIdentifiers.IScopeAnalyzer).to(ScopeAnalyzer).inSingletonScope();
+    options.bind<IScopeAnalyzer>(ServiceIdentifiers.IScopeAnalyzer).to(ScopeAnalyzer).inSingletonScope();
 
     // string array storage analyzer
-    bind<IStringArrayStorageAnalyzer>(ServiceIdentifiers.IStringArrayStorageAnalyzer)
+    options
+        .bind<IStringArrayStorageAnalyzer>(ServiceIdentifiers.IStringArrayStorageAnalyzer)
         .to(StringArrayStorageAnalyzer)
         .inSingletonScope();
 
     // callee data extractors
-    bind<ICalleeDataExtractor>(ServiceIdentifiers.ICalleeDataExtractor)
+    options
+        .bind<ICalleeDataExtractor>(ServiceIdentifiers.ICalleeDataExtractor)
         .to(FunctionDeclarationCalleeDataExtractor)
-        .whenTargetNamed(CalleeDataExtractor.FunctionDeclarationCalleeDataExtractor);
+        .whenNamed(CalleeDataExtractor.FunctionDeclarationCalleeDataExtractor);
 
-    bind<ICalleeDataExtractor>(ServiceIdentifiers.ICalleeDataExtractor)
+    options
+        .bind<ICalleeDataExtractor>(ServiceIdentifiers.ICalleeDataExtractor)
         .to(FunctionExpressionCalleeDataExtractor)
-        .whenTargetNamed(CalleeDataExtractor.FunctionExpressionCalleeDataExtractor);
+        .whenNamed(CalleeDataExtractor.FunctionExpressionCalleeDataExtractor);
 
-    bind<ICalleeDataExtractor>(ServiceIdentifiers.ICalleeDataExtractor)
+    options
+        .bind<ICalleeDataExtractor>(ServiceIdentifiers.ICalleeDataExtractor)
         .to(ObjectExpressionCalleeDataExtractor)
-        .whenTargetNamed(CalleeDataExtractor.ObjectExpressionCalleeDataExtractor);
+        .whenNamed(CalleeDataExtractor.ObjectExpressionCalleeDataExtractor);
 
     // callee data extractor factory
-    bind<ICalleeDataExtractor>(ServiceIdentifiers.Factory__ICalleeDataExtractor).toFactory<
-        ICalleeDataExtractor,
-        [CalleeDataExtractor]
-    >(
-        InversifyContainerFacade.getCacheFactory<CalleeDataExtractor, ICalleeDataExtractor>(
-            ServiceIdentifiers.ICalleeDataExtractor
-        )
-    );
+    options
+        .bind<Factory<ICalleeDataExtractor, [CalleeDataExtractor]>>(ServiceIdentifiers.Factory__ICalleeDataExtractor)
+        .toFactory(
+            InversifyContainerFacade.getCacheFactory<CalleeDataExtractor, ICalleeDataExtractor>(
+                ServiceIdentifiers.ICalleeDataExtractor
+            )
+        );
 });

--- a/src/container/modules/code-transformers/CodeTransformersModule.ts
+++ b/src/container/modules/code-transformers/CodeTransformersModule.ts
@@ -1,5 +1,5 @@
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { ICodeTransformer } from '../../../interfaces/code-transformers/ICodeTransformer';
@@ -10,21 +10,27 @@ import { CodeTransformer } from '../../../enums/code-transformers/CodeTransforme
 import { CodeTransformerNamesGroupsBuilder } from '../../../code-transformers/CodeTransformerNamesGroupsBuilder';
 import { HashbangOperatorTransformer } from '../../../code-transformers/preparing-transformers/HashbangOperatorTransformer';
 
-export const codeTransformersModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const codeTransformersModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // code transformers factory
-    bind<ICodeTransformer>(ServiceIdentifiers.Factory__ICodeTransformer).toFactory<ICodeTransformer, [CodeTransformer]>(
-        InversifyContainerFacade.getCacheFactory<CodeTransformer, ICodeTransformer>(ServiceIdentifiers.ICodeTransformer)
-    );
+    options
+        .bind<Factory<ICodeTransformer, [CodeTransformer]>>(ServiceIdentifiers.Factory__ICodeTransformer)
+        .toFactory(
+            InversifyContainerFacade.getCacheFactory<CodeTransformer, ICodeTransformer>(
+                ServiceIdentifiers.ICodeTransformer
+            )
+        );
 
     // code transformer names groups builder
-    bind<ITransformerNamesGroupsBuilder<CodeTransformer, ICodeTransformer>>(
-        ServiceIdentifiers.ICodeTransformerNamesGroupsBuilder
-    )
+    options
+        .bind<
+            ITransformerNamesGroupsBuilder<CodeTransformer, ICodeTransformer>
+        >(ServiceIdentifiers.ICodeTransformerNamesGroupsBuilder)
         .to(CodeTransformerNamesGroupsBuilder)
         .inSingletonScope();
 
     // preparing code transformers
-    bind<ICodeTransformer>(ServiceIdentifiers.ICodeTransformer)
+    options
+        .bind<ICodeTransformer>(ServiceIdentifiers.ICodeTransformer)
         .to(HashbangOperatorTransformer)
-        .whenTargetNamed(CodeTransformer.HashbangOperatorTransformer);
+        .whenNamed(CodeTransformer.HashbangOperatorTransformer);
 });

--- a/src/container/modules/custom-code-helpers/CustomCodeHelpersModule.ts
+++ b/src/container/modules/custom-code-helpers/CustomCodeHelpersModule.ts
@@ -1,5 +1,5 @@
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { ICustomCodeHelper } from '../../../interfaces/custom-code-helpers/ICustomCodeHelper';
@@ -31,100 +31,123 @@ import { StringArrayCallsWrapperRc4CodeHelper } from '../../../custom-code-helpe
 import { StringArrayCodeHelper } from '../../../custom-code-helpers/string-array/StringArrayCodeHelper';
 import { StringArrayRotateFunctionCodeHelper } from '../../../custom-code-helpers/string-array/StringArrayRotateFunctionCodeHelper';
 
-export const customCodeHelpersModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const customCodeHelpersModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // custom code helpers
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(ConsoleOutputDisableCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.ConsoleOutputDisable);
+        .whenNamed(CustomCodeHelper.ConsoleOutputDisable);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(DebugProtectionFunctionCallCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.DebugProtectionFunctionCall);
+        .whenNamed(CustomCodeHelper.DebugProtectionFunctionCall);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(DebugProtectionFunctionIntervalCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.DebugProtectionFunctionInterval);
+        .whenNamed(CustomCodeHelper.DebugProtectionFunctionInterval);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(DebugProtectionFunctionCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.DebugProtectionFunction);
+        .whenNamed(CustomCodeHelper.DebugProtectionFunction);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(DomainLockCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.DomainLock);
+        .whenNamed(CustomCodeHelper.DomainLock);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(CallsControllerFunctionCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.CallsControllerFunction);
+        .whenNamed(CustomCodeHelper.CallsControllerFunction);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(SelfDefendingCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.SelfDefending);
+        .whenNamed(CustomCodeHelper.SelfDefending);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(StringArrayCallsWrapperCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.StringArrayCallsWrapper);
+        .whenNamed(CustomCodeHelper.StringArrayCallsWrapper);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(StringArrayCallsWrapperBase64CodeHelper)
-        .whenTargetNamed(CustomCodeHelper.StringArrayCallsWrapperBase64);
+        .whenNamed(CustomCodeHelper.StringArrayCallsWrapperBase64);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(StringArrayCallsWrapperRc4CodeHelper)
-        .whenTargetNamed(CustomCodeHelper.StringArrayCallsWrapperRc4);
+        .whenNamed(CustomCodeHelper.StringArrayCallsWrapperRc4);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(StringArrayCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.StringArray);
+        .whenNamed(CustomCodeHelper.StringArray);
 
-    bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
+    options
+        .bind<ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper)
         .to(StringArrayRotateFunctionCodeHelper)
-        .whenTargetNamed(CustomCodeHelper.StringArrayRotateFunction);
+        .whenNamed(CustomCodeHelper.StringArrayRotateFunction);
 
     // code helper groups
-    bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
+    options
+        .bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
         .to(ConsoleOutputCodeHelperGroup)
-        .whenTargetNamed(CustomCodeHelperGroup.ConsoleOutput);
+        .whenNamed(CustomCodeHelperGroup.ConsoleOutput);
 
-    bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
+    options
+        .bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
         .to(DebugProtectionCodeHelperGroup)
-        .whenTargetNamed(CustomCodeHelperGroup.DebugProtection);
+        .whenNamed(CustomCodeHelperGroup.DebugProtection);
 
-    bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
+    options
+        .bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
         .to(DomainLockCustomCodeHelperGroup)
-        .whenTargetNamed(CustomCodeHelperGroup.DomainLock);
+        .whenNamed(CustomCodeHelperGroup.DomainLock);
 
-    bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
+    options
+        .bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
         .to(SelfDefendingCodeHelperGroup)
-        .whenTargetNamed(CustomCodeHelperGroup.SelfDefending);
+        .whenNamed(CustomCodeHelperGroup.SelfDefending);
 
-    bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
+    options
+        .bind<ICustomCodeHelperGroup>(ServiceIdentifiers.ICustomCodeHelperGroup)
         .to(StringArrayCodeHelperGroup)
-        .whenTargetNamed(CustomCodeHelperGroup.StringArray);
+        .whenNamed(CustomCodeHelperGroup.StringArray);
 
     // customCodeHelper factory
-    bind<ICustomCodeHelper>(ServiceIdentifiers.Factory__ICustomCodeHelper).toFactory<
-        ICustomCodeHelper,
-        [CustomCodeHelper]
-    >(InversifyContainerFacade.getFactory<CustomCodeHelper, ICustomCodeHelper>(ServiceIdentifiers.ICustomCodeHelper));
+    options
+        .bind<Factory<ICustomCodeHelper, [CustomCodeHelper]>>(ServiceIdentifiers.Factory__ICustomCodeHelper)
+        .toFactory(
+            InversifyContainerFacade.getFactory<CustomCodeHelper, ICustomCodeHelper>(
+                ServiceIdentifiers.ICustomCodeHelper
+            )
+        );
 
     // customCodeHelperGroup factory
-    bind<ICustomCodeHelperGroup>(ServiceIdentifiers.Factory__ICustomCodeHelperGroup).toFactory<
-        ICustomCodeHelperGroup,
-        [CustomCodeHelperGroup]
-    >(
-        InversifyContainerFacade.getFactory<CustomCodeHelperGroup, ICustomCodeHelperGroup>(
-            ServiceIdentifiers.ICustomCodeHelperGroup
-        )
-    );
+    options
+        .bind<
+            Factory<ICustomCodeHelperGroup, [CustomCodeHelperGroup]>
+        >(ServiceIdentifiers.Factory__ICustomCodeHelperGroup)
+        .toFactory(
+            InversifyContainerFacade.getFactory<CustomCodeHelperGroup, ICustomCodeHelperGroup>(
+                ServiceIdentifiers.ICustomCodeHelperGroup
+            )
+        );
 
     // custom code helper formatter
-    bind<ICustomCodeHelperFormatter>(ServiceIdentifiers.ICustomCodeHelperFormatter)
+    options
+        .bind<ICustomCodeHelperFormatter>(ServiceIdentifiers.ICustomCodeHelperFormatter)
         .to(CustomCodeHelperFormatter)
         .inSingletonScope();
 
     // custom code helper obfuscator
-    bind<ICustomCodeHelperObfuscator>(ServiceIdentifiers.ICustomCodeHelperObfuscator)
+    options
+        .bind<ICustomCodeHelperObfuscator>(ServiceIdentifiers.ICustomCodeHelperObfuscator)
         .to(CustomCodeHelperObfuscator)
         .inSingletonScope();
 });

--- a/src/container/modules/custom-nodes/CustomNodesModule.ts
+++ b/src/container/modules/custom-nodes/CustomNodesModule.ts
@@ -1,5 +1,5 @@
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Newable, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { ICustomNode } from '../../../interfaces/custom-nodes/ICustomNode';
@@ -28,144 +28,159 @@ import { StringArrayScopeCallsWrapperVariableNode } from '../../../custom-nodes/
 import { StringLiteralControlFlowStorageCallNode } from '../../../custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/StringLiteralControlFlowStorageCallNode';
 import { LiteralNode } from '../../../custom-nodes/control-flow-flattening-nodes/LiteralNode';
 
-export const customNodesModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const customNodesModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // control flow custom nodes
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(BinaryExpressionFunctionNode)
-        .whenTargetNamed(ControlFlowCustomNode.BinaryExpressionFunctionNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(BinaryExpressionFunctionNode)
+        .whenNamed(ControlFlowCustomNode.BinaryExpressionFunctionNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(BlockStatementControlFlowFlatteningNode)
-        .whenTargetNamed(ControlFlowCustomNode.BlockStatementControlFlowFlatteningNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(BlockStatementControlFlowFlatteningNode)
+        .whenNamed(ControlFlowCustomNode.BlockStatementControlFlowFlatteningNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(CallExpressionControlFlowStorageCallNode)
-        .whenTargetNamed(ControlFlowCustomNode.CallExpressionControlFlowStorageCallNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(CallExpressionControlFlowStorageCallNode)
+        .whenNamed(ControlFlowCustomNode.CallExpressionControlFlowStorageCallNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(CallExpressionFunctionNode)
-        .whenTargetNamed(ControlFlowCustomNode.CallExpressionFunctionNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(CallExpressionFunctionNode)
+        .whenNamed(ControlFlowCustomNode.CallExpressionFunctionNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(ControlFlowStorageNode)
-        .whenTargetNamed(ControlFlowCustomNode.ControlFlowStorageNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(ControlFlowStorageNode)
+        .whenNamed(ControlFlowCustomNode.ControlFlowStorageNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(ExpressionWithOperatorControlFlowStorageCallNode)
-        .whenTargetNamed(ControlFlowCustomNode.ExpressionWithOperatorControlFlowStorageCallNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(ExpressionWithOperatorControlFlowStorageCallNode)
+        .whenNamed(ControlFlowCustomNode.ExpressionWithOperatorControlFlowStorageCallNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(LiteralNode)
-        .whenTargetNamed(ControlFlowCustomNode.LiteralNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(LiteralNode)
+        .whenNamed(ControlFlowCustomNode.LiteralNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(LogicalExpressionFunctionNode)
-        .whenTargetNamed(ControlFlowCustomNode.LogicalExpressionFunctionNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(LogicalExpressionFunctionNode)
+        .whenNamed(ControlFlowCustomNode.LogicalExpressionFunctionNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(StringLiteralControlFlowStorageCallNode)
-        .whenTargetNamed(ControlFlowCustomNode.StringLiteralControlFlowStorageCallNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(StringLiteralControlFlowStorageCallNode)
+        .whenNamed(ControlFlowCustomNode.StringLiteralControlFlowStorageCallNode);
 
     // dead code injection custom nodes
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(BlockStatementDeadCodeInjectionNode)
-        .whenTargetNamed(DeadCodeInjectionCustomNode.BlockStatementDeadCodeInjectionNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(BlockStatementDeadCodeInjectionNode)
+        .whenNamed(DeadCodeInjectionCustomNode.BlockStatementDeadCodeInjectionNode);
 
     // object expression keys transformer nodes
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(ObjectExpressionVariableDeclarationHostNode)
-        .whenTargetNamed(ObjectExpressionKeysTransformerCustomNode.ObjectExpressionVariableDeclarationHostNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(ObjectExpressionVariableDeclarationHostNode)
+        .whenNamed(ObjectExpressionKeysTransformerCustomNode.ObjectExpressionVariableDeclarationHostNode);
 
     // string array nodes
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(StringArrayCallNode)
-        .whenTargetNamed(StringArrayCustomNode.StringArrayCallNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(StringArrayCallNode)
+        .whenNamed(StringArrayCustomNode.StringArrayCallNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(StringArrayScopeCallsWrapperFunctionNode)
-        .whenTargetNamed(StringArrayCustomNode.StringArrayScopeCallsWrapperFunctionNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(StringArrayScopeCallsWrapperFunctionNode)
+        .whenNamed(StringArrayCustomNode.StringArrayScopeCallsWrapperFunctionNode);
 
-    bind<interfaces.Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
-        .toConstructor(StringArrayScopeCallsWrapperVariableNode)
-        .whenTargetNamed(StringArrayCustomNode.StringArrayScopeCallsWrapperVariableNode);
+    options
+        .bind<Newable<ICustomNode>>(ServiceIdentifiers.Newable__ICustomNode)
+        .toConstantValue(StringArrayScopeCallsWrapperVariableNode)
+        .whenNamed(StringArrayCustomNode.StringArrayScopeCallsWrapperVariableNode);
 
     // string array index nodes
-    bind<IStringArrayIndexNode>(ServiceIdentifiers.IStringArrayIndexNode)
+    options
+        .bind<IStringArrayIndexNode>(ServiceIdentifiers.IStringArrayIndexNode)
         .to(StringArrayHexadecimalNumberIndexNode)
         .inSingletonScope()
-        .whenTargetNamed(StringArrayIndexNode.StringArrayHexadecimalNumberIndexNode);
+        .whenNamed(StringArrayIndexNode.StringArrayHexadecimalNumberIndexNode);
 
-    bind<IStringArrayIndexNode>(ServiceIdentifiers.IStringArrayIndexNode)
+    options
+        .bind<IStringArrayIndexNode>(ServiceIdentifiers.IStringArrayIndexNode)
         .to(StringArrayHexadecimalNumericStringIndexNode)
         .inSingletonScope()
-        .whenTargetNamed(StringArrayIndexNode.StringArrayHexadecimalNumericStringIndexNode);
+        .whenNamed(StringArrayIndexNode.StringArrayHexadecimalNumericStringIndexNode);
 
     // control flow customNode constructor factory
-    bind<ICustomNode>(ServiceIdentifiers.Factory__IControlFlowCustomNode).toFactory<
-        ICustomNode,
-        [ControlFlowCustomNode]
-    >(
-        InversifyContainerFacade.getConstructorFactory<ControlFlowCustomNode, ICustomNode>(
-            ServiceIdentifiers.Newable__ICustomNode,
-            ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
-            ServiceIdentifiers.ICustomCodeHelperFormatter,
-            ServiceIdentifiers.IRandomGenerator,
-            ServiceIdentifiers.IOptions
-        )
-    );
+    options
+        .bind<Factory<ICustomNode, [ControlFlowCustomNode]>>(ServiceIdentifiers.Factory__IControlFlowCustomNode)
+        .toFactory(
+            InversifyContainerFacade.getConstructorFactory<ControlFlowCustomNode, ICustomNode>(
+                ServiceIdentifiers.Newable__ICustomNode,
+                ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
+                ServiceIdentifiers.ICustomCodeHelperFormatter,
+                ServiceIdentifiers.IRandomGenerator,
+                ServiceIdentifiers.IOptions
+            )
+        );
 
     // dead code injection customNode constructor factory
-    bind<ICustomNode>(ServiceIdentifiers.Factory__IDeadCodeInjectionCustomNode).toFactory<
-        ICustomNode,
-        [DeadCodeInjectionCustomNode]
-    >(
-        InversifyContainerFacade.getConstructorFactory<DeadCodeInjectionCustomNode, ICustomNode>(
-            ServiceIdentifiers.Newable__ICustomNode,
-            ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
-            ServiceIdentifiers.ICustomCodeHelperFormatter,
-            ServiceIdentifiers.IRandomGenerator,
-            ServiceIdentifiers.IOptions
-        )
-    );
+    options
+        .bind<
+            Factory<ICustomNode, [DeadCodeInjectionCustomNode]>
+        >(ServiceIdentifiers.Factory__IDeadCodeInjectionCustomNode)
+        .toFactory(
+            InversifyContainerFacade.getConstructorFactory<DeadCodeInjectionCustomNode, ICustomNode>(
+                ServiceIdentifiers.Newable__ICustomNode,
+                ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
+                ServiceIdentifiers.ICustomCodeHelperFormatter,
+                ServiceIdentifiers.IRandomGenerator,
+                ServiceIdentifiers.IOptions
+            )
+        );
 
     // object expression keys transformer customNode constructor factory
-    bind<ICustomNode>(ServiceIdentifiers.Factory__IObjectExpressionKeysTransformerCustomNode).toFactory<
-        ICustomNode,
-        [ObjectExpressionKeysTransformerCustomNode]
-    >(
-        InversifyContainerFacade.getConstructorFactory<ObjectExpressionKeysTransformerCustomNode, ICustomNode>(
-            ServiceIdentifiers.Newable__ICustomNode,
-            ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
-            ServiceIdentifiers.ICustomCodeHelperFormatter,
-            ServiceIdentifiers.IRandomGenerator,
-            ServiceIdentifiers.IOptions
-        )
-    );
+    options
+        .bind<
+            Factory<ICustomNode, [ObjectExpressionKeysTransformerCustomNode]>
+        >(ServiceIdentifiers.Factory__IObjectExpressionKeysTransformerCustomNode)
+        .toFactory(
+            InversifyContainerFacade.getConstructorFactory<ObjectExpressionKeysTransformerCustomNode, ICustomNode>(
+                ServiceIdentifiers.Newable__ICustomNode,
+                ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
+                ServiceIdentifiers.ICustomCodeHelperFormatter,
+                ServiceIdentifiers.IRandomGenerator,
+                ServiceIdentifiers.IOptions
+            )
+        );
 
     // string array customNode constructor factory
-    bind<ICustomNode>(ServiceIdentifiers.Factory__IStringArrayCustomNode).toFactory<
-        ICustomNode,
-        [StringArrayCustomNode]
-    >(
-        InversifyContainerFacade.getConstructorFactory<StringArrayCustomNode, ICustomNode>(
-            ServiceIdentifiers.Newable__ICustomNode,
-            ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
-            ServiceIdentifiers.Factory__IStringArrayIndexNode,
-            ServiceIdentifiers.ICustomCodeHelperFormatter,
-            ServiceIdentifiers.IStringArrayStorage,
-            ServiceIdentifiers.IArrayUtils,
-            ServiceIdentifiers.IRandomGenerator,
-            ServiceIdentifiers.IOptions
-        )
-    );
+    options
+        .bind<Factory<ICustomNode, [StringArrayCustomNode]>>(ServiceIdentifiers.Factory__IStringArrayCustomNode)
+        .toFactory(
+            InversifyContainerFacade.getConstructorFactory<StringArrayCustomNode, ICustomNode>(
+                ServiceIdentifiers.Newable__ICustomNode,
+                ServiceIdentifiers.Factory__IIdentifierNamesGenerator,
+                ServiceIdentifiers.Factory__IStringArrayIndexNode,
+                ServiceIdentifiers.ICustomCodeHelperFormatter,
+                ServiceIdentifiers.IStringArrayStorage,
+                ServiceIdentifiers.IArrayUtils,
+                ServiceIdentifiers.IRandomGenerator,
+                ServiceIdentifiers.IOptions
+            )
+        );
 
     // string array index node factory
-    bind<IStringArrayIndexNode>(ServiceIdentifiers.Factory__IStringArrayIndexNode).toFactory<
-        IStringArrayIndexNode,
-        [StringArrayIndexNode]
-    >(
-        InversifyContainerFacade.getCacheFactory<StringArrayIndexNode, IStringArrayIndexNode>(
-            ServiceIdentifiers.IStringArrayIndexNode
-        )
-    );
+    options
+        .bind<Factory<IStringArrayIndexNode, [StringArrayIndexNode]>>(ServiceIdentifiers.Factory__IStringArrayIndexNode)
+        .toFactory(
+            InversifyContainerFacade.getCacheFactory<StringArrayIndexNode, IStringArrayIndexNode>(
+                ServiceIdentifiers.IStringArrayIndexNode
+            )
+        );
 });

--- a/src/container/modules/generators/GeneratorsModule.ts
+++ b/src/container/modules/generators/GeneratorsModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, ResolutionContext, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { IIdentifierNamesGenerator } from '../../../interfaces/generators/identifier-names-generators/IIdentifierNamesGenerator';
@@ -11,72 +11,76 @@ import { HexadecimalIdentifierNamesGenerator } from '../../../generators/identif
 import { MangledIdentifierNamesGenerator } from '../../../generators/identifier-names-generators/MangledIdentifierNamesGenerator';
 import { MangledShuffledIdentifierNamesGenerator } from '../../../generators/identifier-names-generators/MangledShuffledIdentifierNamesGenerator';
 
-export const generatorsModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const generatorsModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // identifier name generators
-    bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
+    options
+        .bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
         .to(DictionaryIdentifierNamesGenerator)
         .inSingletonScope()
-        .whenTargetNamed(IdentifierNamesGenerator.DictionaryIdentifierNamesGenerator);
+        .whenNamed(IdentifierNamesGenerator.DictionaryIdentifierNamesGenerator);
 
-    bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
+    options
+        .bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
         .to(HexadecimalIdentifierNamesGenerator)
         .inSingletonScope()
-        .whenTargetNamed(IdentifierNamesGenerator.HexadecimalIdentifierNamesGenerator);
+        .whenNamed(IdentifierNamesGenerator.HexadecimalIdentifierNamesGenerator);
 
-    bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
+    options
+        .bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
         .to(MangledIdentifierNamesGenerator)
         .inSingletonScope()
-        .whenTargetNamed(IdentifierNamesGenerator.MangledIdentifierNamesGenerator);
+        .whenNamed(IdentifierNamesGenerator.MangledIdentifierNamesGenerator);
 
-    bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
+    options
+        .bind<IIdentifierNamesGenerator>(ServiceIdentifiers.IIdentifierNamesGenerator)
         .to(MangledShuffledIdentifierNamesGenerator)
         .inSingletonScope()
-        .whenTargetNamed(IdentifierNamesGenerator.MangledShuffledIdentifierNamesGenerator);
+        .whenNamed(IdentifierNamesGenerator.MangledShuffledIdentifierNamesGenerator);
 
     // identifier name generator factory
     function identifierNameGeneratorFactory(): (
-        context: interfaces.Context
-    ) => (options: IOptions) => IIdentifierNamesGenerator {
+        context: ResolutionContext
+    ) => (generatorOptions: IOptions) => IIdentifierNamesGenerator {
         let cachedIdentifierNamesGenerator: IIdentifierNamesGenerator | null = null;
 
-        return (context: interfaces.Context): ((options: IOptions) => IIdentifierNamesGenerator) =>
-            (options: IOptions): IIdentifierNamesGenerator => {
+        return (context: ResolutionContext): ((generatorOptions: IOptions) => IIdentifierNamesGenerator) =>
+            (generatorOptions: IOptions): IIdentifierNamesGenerator => {
                 if (cachedIdentifierNamesGenerator) {
                     return cachedIdentifierNamesGenerator;
                 }
 
                 let identifierNamesGenerator: IIdentifierNamesGenerator;
 
-                switch (options.identifierNamesGenerator) {
+                switch (generatorOptions.identifierNamesGenerator) {
                     case IdentifierNamesGenerator.DictionaryIdentifierNamesGenerator:
-                        identifierNamesGenerator = context.container.getNamed<IIdentifierNamesGenerator>(
+                        identifierNamesGenerator = context.get<IIdentifierNamesGenerator>(
                             ServiceIdentifiers.IIdentifierNamesGenerator,
-                            IdentifierNamesGenerator.DictionaryIdentifierNamesGenerator
+                            { name: IdentifierNamesGenerator.DictionaryIdentifierNamesGenerator }
                         );
 
                         break;
 
                     case IdentifierNamesGenerator.MangledIdentifierNamesGenerator:
-                        identifierNamesGenerator = context.container.getNamed<IIdentifierNamesGenerator>(
+                        identifierNamesGenerator = context.get<IIdentifierNamesGenerator>(
                             ServiceIdentifiers.IIdentifierNamesGenerator,
-                            IdentifierNamesGenerator.MangledIdentifierNamesGenerator
+                            { name: IdentifierNamesGenerator.MangledIdentifierNamesGenerator }
                         );
 
                         break;
 
                     case IdentifierNamesGenerator.MangledShuffledIdentifierNamesGenerator:
-                        identifierNamesGenerator = context.container.getNamed<IIdentifierNamesGenerator>(
+                        identifierNamesGenerator = context.get<IIdentifierNamesGenerator>(
                             ServiceIdentifiers.IIdentifierNamesGenerator,
-                            IdentifierNamesGenerator.MangledShuffledIdentifierNamesGenerator
+                            { name: IdentifierNamesGenerator.MangledShuffledIdentifierNamesGenerator }
                         );
 
                         break;
 
                     case IdentifierNamesGenerator.HexadecimalIdentifierNamesGenerator:
                     default:
-                        identifierNamesGenerator = context.container.getNamed<IIdentifierNamesGenerator>(
+                        identifierNamesGenerator = context.get<IIdentifierNamesGenerator>(
                             ServiceIdentifiers.IIdentifierNamesGenerator,
-                            IdentifierNamesGenerator.HexadecimalIdentifierNamesGenerator
+                            { name: IdentifierNamesGenerator.HexadecimalIdentifierNamesGenerator }
                         );
                 }
 
@@ -85,8 +89,7 @@ export const generatorsModule: interfaces.ContainerModule = new ContainerModule(
                 return identifierNamesGenerator;
             };
     }
-    bind<IIdentifierNamesGenerator>(ServiceIdentifiers.Factory__IIdentifierNamesGenerator).toFactory<
-        IIdentifierNamesGenerator,
-        [IOptions]
-    >(identifierNameGeneratorFactory());
+    options
+        .bind<Factory<IIdentifierNamesGenerator, [IOptions]>>(ServiceIdentifiers.Factory__IIdentifierNamesGenerator)
+        .toFactory(identifierNameGeneratorFactory());
 });

--- a/src/container/modules/node-transformers/ControlFlowTransformersModule.ts
+++ b/src/container/modules/node-transformers/ControlFlowTransformersModule.ts
@@ -1,5 +1,5 @@
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { IControlFlowReplacer } from '../../../interfaces/node-transformers/control-flow-transformers/IControlFlowReplacer';
@@ -17,50 +17,59 @@ import { StringArrayCallControlFlowReplacer } from '../../../node-transformers/c
 import { StringArrayControlFlowTransformer } from '../../../node-transformers/control-flow-transformers/StringArrayControlFlowTransformer';
 import { StringLiteralControlFlowReplacer } from '../../../node-transformers/control-flow-transformers/control-flow-replacers/StringLiteralControlFlowReplacer';
 
-export const controlFlowTransformersModule: interfaces.ContainerModule = new ContainerModule(
-    (bind: interfaces.Bind) => {
+export const controlFlowTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
         // control flow transformers
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(BlockStatementControlFlowTransformer)
-            .whenTargetNamed(NodeTransformer.BlockStatementControlFlowTransformer);
+            .whenNamed(NodeTransformer.BlockStatementControlFlowTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(FunctionControlFlowTransformer)
-            .whenTargetNamed(NodeTransformer.FunctionControlFlowTransformer);
+            .whenNamed(NodeTransformer.FunctionControlFlowTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(StringArrayControlFlowTransformer)
-            .whenTargetNamed(NodeTransformer.StringArrayControlFlowTransformer);
+            .whenNamed(NodeTransformer.StringArrayControlFlowTransformer);
 
         // control flow replacers
-        bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
+        options
+            .bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
             .to(BinaryExpressionControlFlowReplacer)
-            .whenTargetNamed(ControlFlowReplacer.BinaryExpressionControlFlowReplacer);
+            .whenNamed(ControlFlowReplacer.BinaryExpressionControlFlowReplacer);
 
-        bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
+        options
+            .bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
             .to(CallExpressionControlFlowReplacer)
-            .whenTargetNamed(ControlFlowReplacer.CallExpressionControlFlowReplacer);
+            .whenNamed(ControlFlowReplacer.CallExpressionControlFlowReplacer);
 
-        bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
+        options
+            .bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
             .to(LogicalExpressionControlFlowReplacer)
-            .whenTargetNamed(ControlFlowReplacer.LogicalExpressionControlFlowReplacer);
+            .whenNamed(ControlFlowReplacer.LogicalExpressionControlFlowReplacer);
 
-        bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
+        options
+            .bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
             .to(StringArrayCallControlFlowReplacer)
-            .whenTargetNamed(ControlFlowReplacer.StringArrayCallControlFlowReplacer);
+            .whenNamed(ControlFlowReplacer.StringArrayCallControlFlowReplacer);
 
-        bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
+        options
+            .bind<IControlFlowReplacer>(ServiceIdentifiers.IControlFlowReplacer)
             .to(StringLiteralControlFlowReplacer)
-            .whenTargetNamed(ControlFlowReplacer.StringLiteralControlFlowReplacer);
+            .whenNamed(ControlFlowReplacer.StringLiteralControlFlowReplacer);
 
         // control flow replacer factory
-        bind<IControlFlowReplacer>(ServiceIdentifiers.Factory__IControlFlowReplacer).toFactory<
-            IControlFlowReplacer,
-            [ControlFlowReplacer]
-        >(
-            InversifyContainerFacade.getCacheFactory<ControlFlowReplacer, IControlFlowReplacer>(
-                ServiceIdentifiers.IControlFlowReplacer
-            )
-        );
+        options
+            .bind<
+                Factory<IControlFlowReplacer, [ControlFlowReplacer]>
+            >(ServiceIdentifiers.Factory__IControlFlowReplacer)
+            .toFactory(
+                InversifyContainerFacade.getCacheFactory<ControlFlowReplacer, IControlFlowReplacer>(
+                    ServiceIdentifiers.IControlFlowReplacer
+                )
+            );
     }
 );

--- a/src/container/modules/node-transformers/ConvertingTransformersModule.ts
+++ b/src/container/modules/node-transformers/ConvertingTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Factory } from 'inversify';
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
@@ -22,68 +22,84 @@ import { ObjectPatternPropertiesTransformer } from '../../../node-transformers/c
 import { SplitStringTransformer } from '../../../node-transformers/converting-transformers/SplitStringTransformer';
 import { TemplateLiteralTransformer } from '../../../node-transformers/converting-transformers/TemplateLiteralTransformer';
 
-export const convertingTransformersModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
-    // converting transformers
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(BooleanLiteralTransformer)
-        .whenTargetNamed(NodeTransformer.BooleanLiteralTransformer);
+export const convertingTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
+        // converting transformers
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(BooleanLiteralTransformer)
+            .whenNamed(NodeTransformer.BooleanLiteralTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(ExportSpecifierTransformer)
-        .whenTargetNamed(NodeTransformer.ExportSpecifierTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(ExportSpecifierTransformer)
+            .whenNamed(NodeTransformer.ExportSpecifierTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(MemberExpressionTransformer)
-        .whenTargetNamed(NodeTransformer.MemberExpressionTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(MemberExpressionTransformer)
+            .whenNamed(NodeTransformer.MemberExpressionTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(ClassFieldTransformer)
-        .whenTargetNamed(NodeTransformer.ClassFieldTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(ClassFieldTransformer)
+            .whenNamed(NodeTransformer.ClassFieldTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(NumberLiteralTransformer)
-        .whenTargetNamed(NodeTransformer.NumberLiteralTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(NumberLiteralTransformer)
+            .whenNamed(NodeTransformer.NumberLiteralTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(NumberToNumericalExpressionTransformer)
-        .whenTargetNamed(NodeTransformer.NumberToNumericalExpressionTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(NumberToNumericalExpressionTransformer)
+            .whenNamed(NodeTransformer.NumberToNumericalExpressionTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(ObjectExpressionKeysTransformer)
-        .whenTargetNamed(NodeTransformer.ObjectExpressionKeysTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(ObjectExpressionKeysTransformer)
+            .whenNamed(NodeTransformer.ObjectExpressionKeysTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(ObjectExpressionTransformer)
-        .whenTargetNamed(NodeTransformer.ObjectExpressionTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(ObjectExpressionTransformer)
+            .whenNamed(NodeTransformer.ObjectExpressionTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(ObjectPatternPropertiesTransformer)
-        .whenTargetNamed(NodeTransformer.ObjectPatternPropertiesTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(ObjectPatternPropertiesTransformer)
+            .whenNamed(NodeTransformer.ObjectPatternPropertiesTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(SplitStringTransformer)
-        .whenTargetNamed(NodeTransformer.SplitStringTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(SplitStringTransformer)
+            .whenNamed(NodeTransformer.SplitStringTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(TemplateLiteralTransformer)
-        .whenTargetNamed(NodeTransformer.TemplateLiteralTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(TemplateLiteralTransformer)
+            .whenNamed(NodeTransformer.TemplateLiteralTransformer);
 
-    // object expression extractors
-    bind<IObjectExpressionExtractor>(ServiceIdentifiers.IObjectExpressionExtractor)
-        .to(ObjectExpressionToVariableDeclarationExtractor)
-        .whenTargetNamed(ObjectExpressionExtractor.ObjectExpressionToVariableDeclarationExtractor);
+        // object expression extractors
+        options
+            .bind<IObjectExpressionExtractor>(ServiceIdentifiers.IObjectExpressionExtractor)
+            .to(ObjectExpressionToVariableDeclarationExtractor)
+            .whenNamed(ObjectExpressionExtractor.ObjectExpressionToVariableDeclarationExtractor);
 
-    bind<IObjectExpressionExtractor>(ServiceIdentifiers.IObjectExpressionExtractor)
-        .to(BasePropertiesExtractor)
-        .whenTargetNamed(ObjectExpressionExtractor.BasePropertiesExtractor);
+        options
+            .bind<IObjectExpressionExtractor>(ServiceIdentifiers.IObjectExpressionExtractor)
+            .to(BasePropertiesExtractor)
+            .whenNamed(ObjectExpressionExtractor.BasePropertiesExtractor);
 
-    // object expression extractor factory
-    bind<IObjectExpressionExtractor>(ServiceIdentifiers.Factory__IObjectExpressionExtractor).toFactory<
-        IObjectExpressionExtractor,
-        [ObjectExpressionExtractor]
-    >(
-        InversifyContainerFacade.getCacheFactory<ObjectExpressionExtractor, IObjectExpressionExtractor>(
-            ServiceIdentifiers.IObjectExpressionExtractor
-        )
-    );
-});
+        // object expression extractor factory
+        options
+            .bind<
+                Factory<IObjectExpressionExtractor, [ObjectExpressionExtractor]>
+            >(ServiceIdentifiers.Factory__IObjectExpressionExtractor)
+            .toFactory(
+                InversifyContainerFacade.getCacheFactory<ObjectExpressionExtractor, IObjectExpressionExtractor>(
+                    ServiceIdentifiers.IObjectExpressionExtractor
+                )
+            );
+    }
+);

--- a/src/container/modules/node-transformers/DeadCodeInjectionTransformersModule.ts
+++ b/src/container/modules/node-transformers/DeadCodeInjectionTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { INodeTransformer } from '../../../interfaces/node-transformers/INodeTransformer';
@@ -7,11 +7,11 @@ import { NodeTransformer } from '../../../enums/node-transformers/NodeTransforme
 
 import { DeadCodeInjectionTransformer } from '../../../node-transformers/dead-code-injection-transformers/DeadCodeInjectionTransformer';
 
-export const deadCodeInjectionTransformersModule: interfaces.ContainerModule = new ContainerModule(
-    (bind: interfaces.Bind) => {
+export const deadCodeInjectionTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
         // dead code injection
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(DeadCodeInjectionTransformer)
-            .whenTargetNamed(NodeTransformer.DeadCodeInjectionTransformer);
+            .whenNamed(NodeTransformer.DeadCodeInjectionTransformer);
     }
 );

--- a/src/container/modules/node-transformers/FinalizingTransformersModule.ts
+++ b/src/container/modules/node-transformers/FinalizingTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { INodeTransformer } from '../../../interfaces/node-transformers/INodeTransformer';
@@ -8,13 +8,13 @@ import { NodeTransformer } from '../../../enums/node-transformers/NodeTransforme
 import { DirectivePlacementTransformer } from '../../../node-transformers/finalizing-transformers/DirectivePlacementTransformer';
 import { EscapeSequenceTransformer } from '../../../node-transformers/finalizing-transformers/EscapeSequenceTransformer';
 
-export const finalizingTransformersModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const finalizingTransformersModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // finalizing transformers
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+    options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
         .to(DirectivePlacementTransformer)
-        .whenTargetNamed(NodeTransformer.DirectivePlacementTransformer);
+        .whenNamed(NodeTransformer.DirectivePlacementTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+    options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
         .to(EscapeSequenceTransformer)
-        .whenTargetNamed(NodeTransformer.EscapeSequenceTransformer);
+        .whenNamed(NodeTransformer.EscapeSequenceTransformer);
 });

--- a/src/container/modules/node-transformers/InitializingTransformersModule.ts
+++ b/src/container/modules/node-transformers/InitializingTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { INodeTransformer } from '../../../interfaces/node-transformers/INodeTransformer';
@@ -7,11 +7,11 @@ import { NodeTransformer } from '../../../enums/node-transformers/NodeTransforme
 
 import { CommentsTransformer } from '../../../node-transformers/initializing-transformers/CommentsTransformer';
 
-export const initializingTransformersModule: interfaces.ContainerModule = new ContainerModule(
-    (bind: interfaces.Bind) => {
+export const initializingTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
         // preparing transformers
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(CommentsTransformer)
-            .whenTargetNamed(NodeTransformer.CommentsTransformer);
+            .whenNamed(NodeTransformer.CommentsTransformer);
     }
 );

--- a/src/container/modules/node-transformers/NodeTransformersModule.ts
+++ b/src/container/modules/node-transformers/NodeTransformersModule.ts
@@ -1,5 +1,5 @@
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { INodeTransformer } from '../../../interfaces/node-transformers/INodeTransformer';
@@ -9,16 +9,21 @@ import { NodeTransformer } from '../../../enums/node-transformers/NodeTransforme
 
 import { NodeTransformerNamesGroupsBuilder } from '../../../node-transformers/NodeTransformerNamesGroupsBuilder';
 
-export const nodeTransformersModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const nodeTransformersModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // node transformers factory
-    bind<INodeTransformer>(ServiceIdentifiers.Factory__INodeTransformer).toFactory<INodeTransformer, [NodeTransformer]>(
-        InversifyContainerFacade.getCacheFactory<NodeTransformer, INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-    );
+    options
+        .bind<Factory<INodeTransformer, [NodeTransformer]>>(ServiceIdentifiers.Factory__INodeTransformer)
+        .toFactory(
+            InversifyContainerFacade.getCacheFactory<NodeTransformer, INodeTransformer>(
+                ServiceIdentifiers.INodeTransformer
+            )
+        );
 
     // node transformer names groups builder
-    bind<ITransformerNamesGroupsBuilder<NodeTransformer, INodeTransformer>>(
-        ServiceIdentifiers.INodeTransformerNamesGroupsBuilder
-    )
+    options
+        .bind<
+            ITransformerNamesGroupsBuilder<NodeTransformer, INodeTransformer>
+        >(ServiceIdentifiers.INodeTransformerNamesGroupsBuilder)
         .to(NodeTransformerNamesGroupsBuilder)
         .inSingletonScope();
 });

--- a/src/container/modules/node-transformers/PreparingTransformersModule.ts
+++ b/src/container/modules/node-transformers/PreparingTransformersModule.ts
@@ -1,5 +1,5 @@
 import { InversifyContainerFacade } from '../../InversifyContainerFacade';
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { INodeTransformer } from '../../../interfaces/node-transformers/INodeTransformer';
@@ -22,70 +22,89 @@ import { ParentificationTransformer } from '../../../node-transformers/preparing
 import { ReservedStringObfuscatingGuard } from '../../../node-transformers/preparing-transformers/obfuscating-guards/ReservedStringObfuscatingGuard';
 import { VariablePreserveTransformer } from '../../../node-transformers/preparing-transformers/VariablePreserveTransformer';
 
-export const preparingTransformersModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
-    // preparing transformers
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(CustomCodeHelpersTransformer)
-        .whenTargetNamed(NodeTransformer.CustomCodeHelpersTransformer);
+export const preparingTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
+        // preparing transformers
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(CustomCodeHelpersTransformer)
+            .whenNamed(NodeTransformer.CustomCodeHelpersTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(EvalCallExpressionTransformer)
-        .whenTargetNamed(NodeTransformer.EvalCallExpressionTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(EvalCallExpressionTransformer)
+            .whenNamed(NodeTransformer.EvalCallExpressionTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(MetadataTransformer)
-        .whenTargetNamed(NodeTransformer.MetadataTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(MetadataTransformer)
+            .whenNamed(NodeTransformer.MetadataTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(ObfuscatingGuardsTransformer)
-        .whenTargetNamed(NodeTransformer.ObfuscatingGuardsTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(ObfuscatingGuardsTransformer)
+            .whenNamed(NodeTransformer.ObfuscatingGuardsTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(ParentificationTransformer)
-        .whenTargetNamed(NodeTransformer.ParentificationTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(ParentificationTransformer)
+            .whenNamed(NodeTransformer.ParentificationTransformer);
 
-    bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
-        .to(VariablePreserveTransformer)
-        .whenTargetNamed(NodeTransformer.VariablePreserveTransformer);
+        options
+            .bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+            .to(VariablePreserveTransformer)
+            .whenNamed(NodeTransformer.VariablePreserveTransformer);
 
-    // obfuscating guards
-    bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-        .to(BlackListObfuscatingGuard)
-        .inSingletonScope()
-        .whenTargetNamed(ObfuscatingGuard.BlackListObfuscatingGuard);
+        // obfuscating guards
+        options
+            .bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
+            .to(BlackListObfuscatingGuard)
+            .inSingletonScope()
+            .whenNamed(ObfuscatingGuard.BlackListObfuscatingGuard);
 
-    bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-        .to(ConditionalCommentObfuscatingGuard)
-        .inSingletonScope()
-        .whenTargetNamed(ObfuscatingGuard.ConditionalCommentObfuscatingGuard);
+        options
+            .bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
+            .to(ConditionalCommentObfuscatingGuard)
+            .inSingletonScope()
+            .whenNamed(ObfuscatingGuard.ConditionalCommentObfuscatingGuard);
 
-    bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-        .to(ForceTransformStringObfuscatingGuard)
-        .inSingletonScope()
-        .whenTargetNamed(ObfuscatingGuard.ForceTransformStringObfuscatingGuard);
+        options
+            .bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
+            .to(ForceTransformStringObfuscatingGuard)
+            .inSingletonScope()
+            .whenNamed(ObfuscatingGuard.ForceTransformStringObfuscatingGuard);
 
-    bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-        .to(IgnoredImportObfuscatingGuard)
-        .inSingletonScope()
-        .whenTargetNamed(ObfuscatingGuard.IgnoredImportObfuscatingGuard);
+        options
+            .bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
+            .to(IgnoredImportObfuscatingGuard)
+            .inSingletonScope()
+            .whenNamed(ObfuscatingGuard.IgnoredImportObfuscatingGuard);
 
-    bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-        .to(ImportMetaObfuscationGuard)
-        .inSingletonScope()
-        .whenTargetNamed(ObfuscatingGuard.ImportMetaObfuscationGuard);
+        options
+            .bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
+            .to(ImportMetaObfuscationGuard)
+            .inSingletonScope()
+            .whenNamed(ObfuscatingGuard.ImportMetaObfuscationGuard);
 
-    bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-        .to(ProcessEnvObfuscationGuard)
-        .inSingletonScope()
-        .whenTargetNamed(ObfuscatingGuard.ProcessEnvObfuscationGuard);
+        options
+            .bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
+            .to(ProcessEnvObfuscationGuard)
+            .inSingletonScope()
+            .whenNamed(ObfuscatingGuard.ProcessEnvObfuscationGuard);
 
-    bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-        .to(ReservedStringObfuscatingGuard)
-        .inSingletonScope()
-        .whenTargetNamed(ObfuscatingGuard.ReservedStringObfuscatingGuard);
+        options
+            .bind<IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
+            .to(ReservedStringObfuscatingGuard)
+            .inSingletonScope()
+            .whenNamed(ObfuscatingGuard.ReservedStringObfuscatingGuard);
 
-    // obfuscating guards factory
-    bind<IObfuscatingGuard>(ServiceIdentifiers.Factory__INodeGuard).toFactory<IObfuscatingGuard, [ObfuscatingGuard]>(
-        InversifyContainerFacade.getCacheFactory<ObfuscatingGuard, IObfuscatingGuard>(ServiceIdentifiers.INodeGuard)
-    );
-});
+        // obfuscating guards factory
+        options
+            .bind<Factory<IObfuscatingGuard, [ObfuscatingGuard]>>(ServiceIdentifiers.Factory__INodeGuard)
+            .toFactory(
+                InversifyContainerFacade.getCacheFactory<ObfuscatingGuard, IObfuscatingGuard>(
+                    ServiceIdentifiers.INodeGuard
+                )
+            );
+    }
+);

--- a/src/container/modules/node-transformers/RenameIdentifiersTransformersModule.ts
+++ b/src/container/modules/node-transformers/RenameIdentifiersTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { IIdentifierReplacer } from '../../../interfaces/node-transformers/rename-identifiers-transformers/replacer/IIdentifierReplacer';
@@ -14,29 +14,29 @@ import { ScopeThroughIdentifiersTransformer } from '../../../node-transformers/r
 import { ThroughIdentifierReplacer } from '../../../node-transformers/rename-identifiers-transformers/through-replacer/ThroughIdentifierReplacer';
 import { IThroughIdentifierReplacer } from '../../../interfaces/node-transformers/rename-identifiers-transformers/replacer/IThroughIdentifierReplacer';
 
-export const renameIdentifiersTransformersModule: interfaces.ContainerModule = new ContainerModule(
-    (bind: interfaces.Bind) => {
+export const renameIdentifiersTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
         // rename identifiers transformers
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(DeadCodeInjectionIdentifiersTransformer)
-            .whenTargetNamed(NodeTransformer.DeadCodeInjectionIdentifiersTransformer);
+            .whenNamed(NodeTransformer.DeadCodeInjectionIdentifiersTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(LabeledStatementTransformer)
-            .whenTargetNamed(NodeTransformer.LabeledStatementTransformer);
+            .whenNamed(NodeTransformer.LabeledStatementTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(ScopeIdentifiersTransformer)
-            .whenTargetNamed(NodeTransformer.ScopeIdentifiersTransformer);
+            .whenNamed(NodeTransformer.ScopeIdentifiersTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(ScopeThroughIdentifiersTransformer)
-            .whenTargetNamed(NodeTransformer.ScopeThroughIdentifiersTransformer);
+            .whenNamed(NodeTransformer.ScopeThroughIdentifiersTransformer);
 
         // identifier replacer
-        bind<IIdentifierReplacer>(ServiceIdentifiers.IIdentifierReplacer).to(IdentifierReplacer).inSingletonScope();
+        options.bind<IIdentifierReplacer>(ServiceIdentifiers.IIdentifierReplacer).to(IdentifierReplacer).inSingletonScope();
 
-        bind<IThroughIdentifierReplacer>(ServiceIdentifiers.IThroughIdentifierReplacer)
+        options.bind<IThroughIdentifierReplacer>(ServiceIdentifiers.IThroughIdentifierReplacer)
             .to(ThroughIdentifierReplacer)
             .inSingletonScope();
     }

--- a/src/container/modules/node-transformers/RenamePropertiesTransformersModule.ts
+++ b/src/container/modules/node-transformers/RenamePropertiesTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { IRenamePropertiesReplacer } from '../../../interfaces/node-transformers/rename-properties-transformers/replacer/IRenamePropertiesReplacer';
@@ -9,14 +9,14 @@ import { NodeTransformer } from '../../../enums/node-transformers/NodeTransforme
 import { RenamePropertiesReplacer } from '../../../node-transformers/rename-properties-transformers/replacer/RenamePropertiesReplacer';
 import { RenamePropertiesTransformer } from '../../../node-transformers/rename-properties-transformers/RenamePropertiesTransformer';
 
-export const renamePropertiesTransformersModule: interfaces.ContainerModule = new ContainerModule(
-    (bind: interfaces.Bind) => {
+export const renamePropertiesTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
         // rename properties transformers
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(RenamePropertiesTransformer)
-            .whenTargetNamed(NodeTransformer.RenamePropertiesTransformer);
+            .whenNamed(NodeTransformer.RenamePropertiesTransformer);
 
         // rename properties obfuscating replacer
-        bind<IRenamePropertiesReplacer>(ServiceIdentifiers.IRenamePropertiesReplacer).to(RenamePropertiesReplacer);
+        options.bind<IRenamePropertiesReplacer>(ServiceIdentifiers.IRenamePropertiesReplacer).to(RenamePropertiesReplacer);
     }
 );

--- a/src/container/modules/node-transformers/SimplifyingTransformersModule.ts
+++ b/src/container/modules/node-transformers/SimplifyingTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { INodeTransformer } from '../../../interfaces/node-transformers/INodeTransformer';
@@ -10,23 +10,23 @@ import { ExpressionStatementsMergeTransformer } from '../../../node-transformers
 import { IfStatementSimplifyTransformer } from '../../../node-transformers/simplifying-transformers/IfStatementSimplifyTransformer';
 import { VariableDeclarationsMergeTransformer } from '../../../node-transformers/simplifying-transformers/VariableDeclarationsMergeTransformer';
 
-export const simplifyingTransformersModule: interfaces.ContainerModule = new ContainerModule(
-    (bind: interfaces.Bind) => {
+export const simplifyingTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
         // simplifying transformers
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(BlockStatementSimplifyTransformer)
-            .whenTargetNamed(NodeTransformer.BlockStatementSimplifyTransformer);
+            .whenNamed(NodeTransformer.BlockStatementSimplifyTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(ExpressionStatementsMergeTransformer)
-            .whenTargetNamed(NodeTransformer.ExpressionStatementsMergeTransformer);
+            .whenNamed(NodeTransformer.ExpressionStatementsMergeTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(IfStatementSimplifyTransformer)
-            .whenTargetNamed(NodeTransformer.IfStatementSimplifyTransformer);
+            .whenNamed(NodeTransformer.IfStatementSimplifyTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(VariableDeclarationsMergeTransformer)
-            .whenTargetNamed(NodeTransformer.VariableDeclarationsMergeTransformer);
+            .whenNamed(NodeTransformer.VariableDeclarationsMergeTransformer);
     }
 );

--- a/src/container/modules/node-transformers/StringArrayTransformersModule.ts
+++ b/src/container/modules/node-transformers/StringArrayTransformersModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { INodeTransformer } from '../../../interfaces/node-transformers/INodeTransformer';
@@ -9,19 +9,19 @@ import { StringArrayRotateFunctionTransformer } from '../../../node-transformers
 import { StringArrayScopeCallsWrapperTransformer } from '../../../node-transformers/string-array-transformers/StringArrayScopeCallsWrapperTransformer';
 import { StringArrayTransformer } from '../../../node-transformers/string-array-transformers/StringArrayTransformer';
 
-export const stringArrayTransformersModule: interfaces.ContainerModule = new ContainerModule(
-    (bind: interfaces.Bind) => {
+export const stringArrayTransformersModule: ContainerModule = new ContainerModule(
+    (options: ContainerModuleLoadOptions) => {
         // strings transformers
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(StringArrayRotateFunctionTransformer)
-            .whenTargetNamed(NodeTransformer.StringArrayRotateFunctionTransformer);
+            .whenNamed(NodeTransformer.StringArrayRotateFunctionTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(StringArrayScopeCallsWrapperTransformer)
-            .whenTargetNamed(NodeTransformer.StringArrayScopeCallsWrapperTransformer);
+            .whenNamed(NodeTransformer.StringArrayScopeCallsWrapperTransformer);
 
-        bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
+        options.bind<INodeTransformer>(ServiceIdentifiers.INodeTransformer)
             .to(StringArrayTransformer)
-            .whenTargetNamed(NodeTransformer.StringArrayTransformer);
+            .whenNamed(NodeTransformer.StringArrayTransformer);
     }
 );

--- a/src/container/modules/node/NodeModule.ts
+++ b/src/container/modules/node/NodeModule.ts
@@ -1,13 +1,13 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { IScopeIdentifiersTraverser } from '../../../interfaces/node/IScopeIdentifiersTraverser';
 
 import { ScopeIdentifiersTraverser } from '../../../node/ScopeIdentifiersTraverser';
 
-export const nodeModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const nodeModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // scope identifiers traverser
-    bind<IScopeIdentifiersTraverser>(ServiceIdentifiers.IScopeIdentifiersTraverser)
+    options.bind<IScopeIdentifiersTraverser>(ServiceIdentifiers.IScopeIdentifiersTraverser)
         .to(ScopeIdentifiersTraverser)
         .inSingletonScope();
 });

--- a/src/container/modules/options/OptionsModule.ts
+++ b/src/container/modules/options/OptionsModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { IOptions } from '../../../interfaces/options/IOptions';
@@ -7,8 +7,8 @@ import { IOptionsNormalizer } from '../../../interfaces/options/IOptionsNormaliz
 import { Options } from '../../../options/Options';
 import { OptionsNormalizer } from '../../../options/OptionsNormalizer';
 
-export const optionsModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
-    bind<IOptions>(ServiceIdentifiers.IOptions).to(Options).inSingletonScope();
+export const optionsModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
+    options.bind<IOptions>(ServiceIdentifiers.IOptions).to(Options).inSingletonScope();
 
-    bind<IOptionsNormalizer>(ServiceIdentifiers.IOptionsNormalizer).to(OptionsNormalizer).inSingletonScope();
+    options.bind<IOptionsNormalizer>(ServiceIdentifiers.IOptionsNormalizer).to(OptionsNormalizer).inSingletonScope();
 });

--- a/src/container/modules/storages/StoragesModule.ts
+++ b/src/container/modules/storages/StoragesModule.ts
@@ -1,8 +1,6 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions, ResolutionContext, Factory } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
-import { TControlFlowStorageFactory } from '../../../types/container/node-transformers/TControlFlowStorageFactory';
-import { TControlFlowStorageFactoryCreator } from '../../../types/container/node-transformers/TControlFlowStorageFactoryCreator';
 import { TCustomCodeHelperGroupStorage } from '../../../types/storages/TCustomCodeHelperGroupStorage';
 
 import { IControlFlowStorage } from '../../../interfaces/storages/control-flow-transformers/IControlFlowStorage';
@@ -25,50 +23,59 @@ import { StringControlFlowStorage } from '../../../storages/control-flow-transfo
 import { StringArrayStorage } from '../../../storages/string-array-transformers/StringArrayStorage';
 import { VisitedLexicalScopeNodesStackStorage } from '../../../storages/string-array-transformers/VisitedLexicalScopeNodesStackStorage';
 
-export const storagesModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const storagesModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // storages
-    bind<TCustomCodeHelperGroupStorage>(ServiceIdentifiers.TCustomNodeGroupStorage)
+    options
+        .bind<TCustomCodeHelperGroupStorage>(ServiceIdentifiers.TCustomNodeGroupStorage)
         .to(CustomCodeHelperGroupStorage)
         .inSingletonScope();
 
-    bind<IControlFlowStorage>(ServiceIdentifiers.IControlFlowStorage)
+    options
+        .bind<IControlFlowStorage>(ServiceIdentifiers.IControlFlowStorage)
         .to(FunctionControlFlowStorage)
-        .whenTargetNamed(ControlFlowStorage.FunctionControlFlowStorage);
+        .whenNamed(ControlFlowStorage.FunctionControlFlowStorage);
 
-    bind<IGlobalIdentifierNamesCacheStorage>(ServiceIdentifiers.IGlobalIdentifierNamesCacheStorage)
+    options
+        .bind<IGlobalIdentifierNamesCacheStorage>(ServiceIdentifiers.IGlobalIdentifierNamesCacheStorage)
         .to(GlobalIdentifierNamesCacheStorage)
         .inSingletonScope();
 
-    bind<ILiteralNodesCacheStorage>(ServiceIdentifiers.ILiteralNodesCacheStorage)
+    options
+        .bind<ILiteralNodesCacheStorage>(ServiceIdentifiers.ILiteralNodesCacheStorage)
         .to(LiteralNodesCacheStorage)
         .inSingletonScope();
 
-    bind<IPropertyIdentifierNamesCacheStorage>(ServiceIdentifiers.IPropertyIdentifierNamesCacheStorage)
+    options
+        .bind<IPropertyIdentifierNamesCacheStorage>(ServiceIdentifiers.IPropertyIdentifierNamesCacheStorage)
         .to(PropertyIdentifierNamesCacheStorage)
         .inSingletonScope();
 
-    bind<IStringArrayStorage>(ServiceIdentifiers.IStringArrayStorage).to(StringArrayStorage).inSingletonScope();
+    options.bind<IStringArrayStorage>(ServiceIdentifiers.IStringArrayStorage).to(StringArrayStorage).inSingletonScope();
 
-    bind<IStringArrayScopeCallsWrappersDataStorage>(ServiceIdentifiers.IStringArrayScopeCallsWrappersDataStorage)
+    options
+        .bind<IStringArrayScopeCallsWrappersDataStorage>(ServiceIdentifiers.IStringArrayScopeCallsWrappersDataStorage)
         .to(StringArrayScopeCallsWrappersDataStorage)
         .inSingletonScope();
 
-    bind<IControlFlowStorage>(ServiceIdentifiers.IControlFlowStorage)
+    options
+        .bind<IControlFlowStorage>(ServiceIdentifiers.IControlFlowStorage)
         .to(StringControlFlowStorage)
-        .whenTargetNamed(ControlFlowStorage.StringControlFlowStorage);
+        .whenNamed(ControlFlowStorage.StringControlFlowStorage);
 
-    bind<IVisitedLexicalScopeNodesStackStorage>(ServiceIdentifiers.IVisitedLexicalScopeNodesStackStorage)
+    options
+        .bind<IVisitedLexicalScopeNodesStackStorage>(ServiceIdentifiers.IVisitedLexicalScopeNodesStackStorage)
         .to(VisitedLexicalScopeNodesStackStorage)
         .inSingletonScope();
 
     // controlFlowStorage factory
-    bind<IControlFlowStorage>(ServiceIdentifiers.Factory__TControlFlowStorage).toFactory(
-        (context: interfaces.Context): TControlFlowStorageFactoryCreator =>
-            (controlFlowStorageName: ControlFlowStorage): TControlFlowStorageFactory =>
-            (): IControlFlowStorage =>
-                context.container.getNamed<IControlFlowStorage>(
-                    ServiceIdentifiers.IControlFlowStorage,
-                    controlFlowStorageName
-                )
-    );
+    options
+        .bind<Factory<() => IControlFlowStorage, [ControlFlowStorage]>>(ServiceIdentifiers.Factory__TControlFlowStorage)
+        .toFactory(
+            (context: ResolutionContext) =>
+                (controlFlowStorageName: ControlFlowStorage): (() => IControlFlowStorage) =>
+                () =>
+                    context.get<IControlFlowStorage>(ServiceIdentifiers.IControlFlowStorage, {
+                        name: controlFlowStorageName
+                    })
+        );
 });

--- a/src/container/modules/utils/UtilsModule.ts
+++ b/src/container/modules/utils/UtilsModule.ts
@@ -1,4 +1,4 @@
-import { ContainerModule, interfaces } from 'inversify';
+import { ContainerModule, ContainerModuleLoadOptions } from 'inversify';
 import { ServiceIdentifiers } from '../../ServiceIdentifiers';
 
 import { IArrayUtils } from '../../../interfaces/utils/IArrayUtils';
@@ -17,29 +17,29 @@ import { LevelledTopologicalSorter } from '../../../utils/LevelledTopologicalSor
 import { RandomGenerator } from '../../../utils/RandomGenerator';
 import { SetUtils } from '../../../utils/SetUtils';
 
-export const utilsModule: interfaces.ContainerModule = new ContainerModule((bind: interfaces.Bind) => {
+export const utilsModule: ContainerModule = new ContainerModule((options: ContainerModuleLoadOptions) => {
     // array utils
-    bind<IArrayUtils>(ServiceIdentifiers.IArrayUtils).to(ArrayUtils).inSingletonScope();
+    options.bind<IArrayUtils>(ServiceIdentifiers.IArrayUtils).to(ArrayUtils).inSingletonScope();
 
     // random generator
-    bind<IRandomGenerator>(ServiceIdentifiers.IRandomGenerator).to(RandomGenerator).inSingletonScope();
+    options.bind<IRandomGenerator>(ServiceIdentifiers.IRandomGenerator).to(RandomGenerator).inSingletonScope();
 
     // crypt utils
-    bind<ICryptUtils>(ServiceIdentifiers.ICryptUtils).to(CryptUtils).inSingletonScope();
+    options.bind<ICryptUtils>(ServiceIdentifiers.ICryptUtils).to(CryptUtils).inSingletonScope();
 
     // crypt utils for string array
-    bind<ICryptUtilsStringArray>(ServiceIdentifiers.ICryptUtilsStringArray)
+    options.bind<ICryptUtilsStringArray>(ServiceIdentifiers.ICryptUtilsStringArray)
         .to(CryptUtilsStringArray)
         .inSingletonScope();
 
     // escape sequence encoder
-    bind<IEscapeSequenceEncoder>(ServiceIdentifiers.IEscapeSequenceEncoder)
+    options.bind<IEscapeSequenceEncoder>(ServiceIdentifiers.IEscapeSequenceEncoder)
         .to(EscapeSequenceEncoder)
         .inSingletonScope();
 
     // levelled topological sorter
-    bind<ILevelledTopologicalSorter>(ServiceIdentifiers.ILevelledTopologicalSorter).to(LevelledTopologicalSorter);
+    options.bind<ILevelledTopologicalSorter>(ServiceIdentifiers.ILevelledTopologicalSorter).to(LevelledTopologicalSorter);
 
     // set utils
-    bind<ISetUtils>(ServiceIdentifiers.ISetUtils).to(SetUtils).inSingletonScope();
+    options.bind<ISetUtils>(ServiceIdentifiers.ISetUtils).to(SetUtils).inSingletonScope();
 });

--- a/src/custom-code-helpers/calls-controller/CallsControllerFunctionCodeHelper.ts
+++ b/src/custom-code-helpers/calls-controller/CallsControllerFunctionCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -18,6 +18,7 @@ import { SingleCallControllerTemplate } from '../common/templates/SingleCallCont
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class CallsControllerFunctionCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/console-output/ConsoleOutputDisableCodeHelper.ts
+++ b/src/custom-code-helpers/console-output/ConsoleOutputDisableCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -16,6 +16,7 @@ import { initializable } from '../../decorators/Initializable';
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class ConsoleOutputDisableCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/console-output/group/ConsoleOutputCodeHelperGroup.ts
+++ b/src/custom-code-helpers/console-output/group/ConsoleOutputCodeHelperGroup.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import { TCustomCodeHelperFactory } from '../../../types/container/custom-code-helpers/TCustomCodeHelperFactory';
@@ -23,6 +23,7 @@ import { ConsoleOutputDisableCodeHelper } from '../ConsoleOutputDisableCodeHelpe
 import { NodeAppender } from '../../../node/NodeAppender';
 import { NodeLexicalScopeUtils } from '../../../node/NodeLexicalScopeUtils';
 
+@injectFromBase()
 @injectable()
 export class ConsoleOutputCodeHelperGroup extends AbstractCustomCodeHelperGroup {
     /**

--- a/src/custom-code-helpers/debug-protection/DebugProtectionFunctionCallCodeHelper.ts
+++ b/src/custom-code-helpers/debug-protection/DebugProtectionFunctionCallCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -16,6 +16,7 @@ import { DebugProtectionFunctionCallTemplate } from './templates/debug-protectio
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class DebugProtectionFunctionCallCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/debug-protection/DebugProtectionFunctionCodeHelper.ts
+++ b/src/custom-code-helpers/debug-protection/DebugProtectionFunctionCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -20,6 +20,7 @@ import { DebugProtectionFunctionTemplate } from './templates/debug-protection-fu
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class DebugProtectionFunctionCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/debug-protection/DebugProtectionFunctionIntervalCodeHelper.ts
+++ b/src/custom-code-helpers/debug-protection/DebugProtectionFunctionIntervalCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -19,6 +19,7 @@ import { GlobalVariableNoEvalTemplate } from '../common/templates/GlobalVariable
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class DebugProtectionFunctionIntervalCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/debug-protection/group/DebugProtectionCodeHelperGroup.ts
+++ b/src/custom-code-helpers/debug-protection/group/DebugProtectionCodeHelperGroup.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import { TCustomCodeHelperFactory } from '../../../types/container/custom-code-helpers/TCustomCodeHelperFactory';
@@ -26,6 +26,7 @@ import { NodeAppender } from '../../../node/NodeAppender';
 import { NodeGuards } from '../../../node/NodeGuards';
 import { NodeLexicalScopeUtils } from '../../../node/NodeLexicalScopeUtils';
 
+@injectFromBase()
 @injectable()
 export class DebugProtectionCodeHelperGroup extends AbstractCustomCodeHelperGroup {
     /**

--- a/src/custom-code-helpers/domain-lock/DomainLockCodeHelper.ts
+++ b/src/custom-code-helpers/domain-lock/DomainLockCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -20,6 +20,7 @@ import { GlobalVariableNoEvalTemplate } from '../common/templates/GlobalVariable
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class DomainLockCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/domain-lock/group/DomainLockCustomCodeHelperGroup.ts
+++ b/src/custom-code-helpers/domain-lock/group/DomainLockCustomCodeHelperGroup.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import { TCustomCodeHelperFactory } from '../../../types/container/custom-code-helpers/TCustomCodeHelperFactory';
@@ -23,6 +23,7 @@ import { DomainLockCodeHelper } from '../DomainLockCodeHelper';
 import { NodeAppender } from '../../../node/NodeAppender';
 import { NodeLexicalScopeUtils } from '../../../node/NodeLexicalScopeUtils';
 
+@injectFromBase()
 @injectable()
 export class DomainLockCustomCodeHelperGroup extends AbstractCustomCodeHelperGroup {
     /**

--- a/src/custom-code-helpers/self-defending/SelfDefendingCodeHelper.ts
+++ b/src/custom-code-helpers/self-defending/SelfDefendingCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -16,6 +16,7 @@ import { SelfDefendingTemplate } from './templates/SelfDefendingTemplate';
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class SelfDefendingCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/self-defending/group/SelfDefendingCodeHelperGroup.ts
+++ b/src/custom-code-helpers/self-defending/group/SelfDefendingCodeHelperGroup.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import { TCustomCodeHelperFactory } from '../../../types/container/custom-code-helpers/TCustomCodeHelperFactory';
@@ -23,6 +23,7 @@ import { NodeAppender } from '../../../node/NodeAppender';
 import { NodeLexicalScopeUtils } from '../../../node/NodeLexicalScopeUtils';
 import { SelfDefendingCodeHelper } from '../SelfDefendingCodeHelper';
 
+@injectFromBase()
 @injectable()
 export class SelfDefendingCodeHelperGroup extends AbstractCustomCodeHelperGroup {
     /**

--- a/src/custom-code-helpers/string-array/StringArrayCallsWrapperBase64CodeHelper.ts
+++ b/src/custom-code-helpers/string-array/StringArrayCallsWrapperBase64CodeHelper.ts
@@ -1,10 +1,11 @@
-import { injectable } from 'inversify';
+import { injectable, injectFromBase } from 'inversify';
 
 import { AtobTemplate } from './templates/string-array-calls-wrapper/AtobTemplate';
 import { StringArrayBase64DecodeTemplate } from './templates/string-array-calls-wrapper/StringArrayBase64DecodeTemplate';
 
 import { StringArrayCallsWrapperCodeHelper } from './StringArrayCallsWrapperCodeHelper';
 
+@injectFromBase()
 @injectable()
 export class StringArrayCallsWrapperBase64CodeHelper extends StringArrayCallsWrapperCodeHelper {
     /**

--- a/src/custom-code-helpers/string-array/StringArrayCallsWrapperCodeHelper.ts
+++ b/src/custom-code-helpers/string-array/StringArrayCallsWrapperCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -18,6 +18,7 @@ import { StringArrayCallsWrapperTemplate } from './templates/string-array-calls-
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class StringArrayCallsWrapperCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/string-array/StringArrayCallsWrapperRc4CodeHelper.ts
+++ b/src/custom-code-helpers/string-array/StringArrayCallsWrapperRc4CodeHelper.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { injectable, injectFromBase } from 'inversify';
 
 import { AtobTemplate } from './templates/string-array-calls-wrapper/AtobTemplate';
 import { Rc4Template } from './templates/string-array-calls-wrapper/Rc4Template';
@@ -6,6 +6,7 @@ import { StringArrayRC4DecodeTemplate } from './templates/string-array-calls-wra
 
 import { StringArrayCallsWrapperCodeHelper } from './StringArrayCallsWrapperCodeHelper';
 
+@injectFromBase()
 @injectable()
 export class StringArrayCallsWrapperRc4CodeHelper extends StringArrayCallsWrapperCodeHelper {
     /**

--- a/src/custom-code-helpers/string-array/StringArrayCodeHelper.ts
+++ b/src/custom-code-helpers/string-array/StringArrayCodeHelper.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -19,6 +19,7 @@ import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 import { StringUtils } from '../../utils/StringUtils';
 
+@injectFromBase()
 @injectable()
 export class StringArrayCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/string-array/StringArrayRotateFunctionCodeHelper.ts
+++ b/src/custom-code-helpers/string-array/StringArrayRotateFunctionCodeHelper.ts
@@ -1,5 +1,5 @@
 import type { Expression } from 'estree';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -17,6 +17,7 @@ import { StringArrayRotateFunctionTemplate } from './templates/string-array-rota
 import { AbstractCustomCodeHelper } from '../AbstractCustomCodeHelper';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class StringArrayRotateFunctionCodeHelper extends AbstractCustomCodeHelper {
     /**

--- a/src/custom-code-helpers/string-array/group/StringArrayCodeHelperGroup.ts
+++ b/src/custom-code-helpers/string-array/group/StringArrayCodeHelperGroup.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import { TCustomCodeHelperFactory } from '../../../types/container/custom-code-helpers/TCustomCodeHelperFactory';
@@ -24,6 +24,7 @@ import { NodeAppender } from '../../../node/NodeAppender';
 import { StringArrayCallsWrapperCodeHelper } from '../StringArrayCallsWrapperCodeHelper';
 import { StringArrayCodeHelper } from '../StringArrayCodeHelper';
 
+@injectFromBase()
 @injectable()
 export class StringArrayCodeHelperGroup extends AbstractCustomCodeHelperGroup {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/BinaryExpressionFunctionNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/BinaryExpressionFunctionNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import type { BinaryOperator } from 'estree';
@@ -14,6 +14,7 @@ import { AbstractCustomNode } from '../AbstractCustomNode';
 import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class BinaryExpressionFunctionNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/BlockStatementControlFlowFlatteningNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/BlockStatementControlFlowFlatteningNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -19,6 +19,7 @@ import { NodeFactory } from '../../node/NodeFactory';
 import { NodeGuards } from '../../node/NodeGuards';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class BlockStatementControlFlowFlatteningNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/CallExpressionFunctionNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/CallExpressionFunctionNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -17,6 +17,7 @@ import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 import { NodeGuards } from '../../node/NodeGuards';
 
+@injectFromBase()
 @injectable()
 export class CallExpressionFunctionNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/LiteralNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/LiteralNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import type * as ESTree from 'estree';
@@ -15,6 +15,7 @@ import { initializable } from '../../decorators/Initializable';
 import { AbstractCustomNode } from '../AbstractCustomNode';
 import { NodeFactory } from '../../node/NodeFactory';
 
+@injectFromBase()
 @injectable()
 export class LiteralNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/LogicalExpressionFunctionNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/LogicalExpressionFunctionNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import type { LogicalOperator } from 'estree';
@@ -14,6 +14,7 @@ import { AbstractCustomNode } from '../AbstractCustomNode';
 import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class LogicalExpressionFunctionNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/CallExpressionControlFlowStorageCallNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/CallExpressionControlFlowStorageCallNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import type * as ESTree from 'estree';
@@ -16,6 +16,7 @@ import { AbstractCustomNode } from '../../AbstractCustomNode';
 import { NodeFactory } from '../../../node/NodeFactory';
 import { NodeUtils } from '../../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class CallExpressionControlFlowStorageCallNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/ControlFlowStorageNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/ControlFlowStorageNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -18,6 +18,7 @@ import { AbstractCustomNode } from '../../AbstractCustomNode';
 import { NodeFactory } from '../../../node/NodeFactory';
 import { NodeGuards } from '../../../node/NodeGuards';
 
+@injectFromBase()
 @injectable()
 export class ControlFlowStorageNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/ExpressionWithOperatorControlFlowStorageCallNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/ExpressionWithOperatorControlFlowStorageCallNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import type { Expression } from 'estree';
@@ -16,6 +16,7 @@ import { AbstractCustomNode } from '../../AbstractCustomNode';
 import { NodeFactory } from '../../../node/NodeFactory';
 import { NodeUtils } from '../../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class ExpressionWithOperatorControlFlowStorageCallNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/StringLiteralControlFlowStorageCallNode.ts
+++ b/src/custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/StringLiteralControlFlowStorageCallNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -14,6 +14,7 @@ import { AbstractCustomNode } from '../../AbstractCustomNode';
 import { NodeFactory } from '../../../node/NodeFactory';
 import { NodeUtils } from '../../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class StringLiteralControlFlowStorageCallNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/dead-code-injection-nodes/BlockStatementDeadCodeInjectionNode.ts
+++ b/src/custom-nodes/dead-code-injection-nodes/BlockStatementDeadCodeInjectionNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import type { BinaryOperator, BlockStatement } from 'estree';
@@ -14,6 +14,7 @@ import { AbstractCustomNode } from '../AbstractCustomNode';
 import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class BlockStatementDeadCodeInjectionNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/object-expression-keys-transformer-nodes/ObjectExpressionVariableDeclarationHostNode.ts
+++ b/src/custom-nodes/object-expression-keys-transformer-nodes/ObjectExpressionVariableDeclarationHostNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -15,6 +15,7 @@ import { AbstractCustomNode } from '../AbstractCustomNode';
 import { NodeFactory } from '../../node/NodeFactory';
 import { NodeGuards } from '../../node/NodeGuards';
 
+@injectFromBase()
 @injectable()
 export class ObjectExpressionVariableDeclarationHostNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/string-array-nodes/AbstractStringArrayCallNode.ts
+++ b/src/custom-nodes/string-array-nodes/AbstractStringArrayCallNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -21,6 +21,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 import { NodeUtils } from '../../node/NodeUtils';
 import { IArrayUtils } from '../../interfaces/utils/IArrayUtils';
 
+@injectFromBase()
 @injectable()
 export abstract class AbstractStringArrayCallNode extends AbstractCustomNode {
     /**

--- a/src/custom-nodes/string-array-nodes/StringArrayCallNode.ts
+++ b/src/custom-nodes/string-array-nodes/StringArrayCallNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -20,6 +20,7 @@ import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 import { IStringArrayScopeCallsWrapperData } from '../../interfaces/node-transformers/string-array-transformers/IStringArrayScopeCallsWrapperData';
 
+@injectFromBase()
 @injectable()
 export class StringArrayCallNode extends AbstractStringArrayCallNode {
     /**

--- a/src/custom-nodes/string-array-nodes/StringArrayScopeCallsWrapperFunctionNode.ts
+++ b/src/custom-nodes/string-array-nodes/StringArrayScopeCallsWrapperFunctionNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -20,6 +20,7 @@ import { AbstractStringArrayCallNode } from './AbstractStringArrayCallNode';
 import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class StringArrayScopeCallsWrapperFunctionNode extends AbstractStringArrayCallNode {
     /**

--- a/src/custom-nodes/string-array-nodes/StringArrayScopeCallsWrapperVariableNode.ts
+++ b/src/custom-nodes/string-array-nodes/StringArrayScopeCallsWrapperVariableNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -18,6 +18,7 @@ import { AbstractStringArrayCallNode } from './AbstractStringArrayCallNode';
 import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class StringArrayScopeCallsWrapperVariableNode extends AbstractStringArrayCallNode {
     /**

--- a/src/custom-nodes/string-array-nodes/string-array-index-nodes/StringArrayHexadecimalNumberIndexNode.ts
+++ b/src/custom-nodes/string-array-nodes/string-array-index-nodes/StringArrayHexadecimalNumberIndexNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 
 import * as ESTree from 'estree';
 
@@ -11,6 +11,7 @@ import { AbstractStringArrayIndexNode } from './AbstractStringArrayIndexNode';
 import { NodeFactory } from '../../../node/NodeFactory';
 import { NumberUtils } from '../../../utils/NumberUtils';
 
+@injectFromBase()
 @injectable()
 export class StringArrayHexadecimalNumberIndexNode extends AbstractStringArrayIndexNode {
     /**

--- a/src/custom-nodes/string-array-nodes/string-array-index-nodes/StringArrayHexadecimalNumericStringIndexNode.ts
+++ b/src/custom-nodes/string-array-nodes/string-array-index-nodes/StringArrayHexadecimalNumericStringIndexNode.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 
 import * as ESTree from 'estree';
 
@@ -11,6 +11,7 @@ import { AbstractStringArrayIndexNode } from './AbstractStringArrayIndexNode';
 import { NodeFactory } from '../../../node/NodeFactory';
 import { NumberUtils } from '../../../utils/NumberUtils';
 
+@injectFromBase()
 @injectable()
 export class StringArrayHexadecimalNumericStringIndexNode extends AbstractStringArrayIndexNode {
     /**

--- a/src/generators/identifier-names-generators/DictionaryIdentifierNamesGenerator.ts
+++ b/src/generators/identifier-names-generators/DictionaryIdentifierNamesGenerator.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { IArrayUtils } from '../../interfaces/utils/IArrayUtils';
@@ -9,6 +9,7 @@ import { AbstractIdentifierNamesGenerator } from './AbstractIdentifierNamesGener
 import { TNodeWithLexicalScope } from '../../types/node/TNodeWithLexicalScope';
 import { NodeLexicalScopeUtils } from '../../node/NodeLexicalScopeUtils';
 
+@injectFromBase()
 @injectable()
 export class DictionaryIdentifierNamesGenerator extends AbstractIdentifierNamesGenerator {
     /**

--- a/src/generators/identifier-names-generators/HexadecimalIdentifierNamesGenerator.ts
+++ b/src/generators/identifier-names-generators/HexadecimalIdentifierNamesGenerator.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TNodeWithLexicalScope } from '../../types/node/TNodeWithLexicalScope';
@@ -10,6 +10,7 @@ import { AbstractIdentifierNamesGenerator } from './AbstractIdentifierNamesGener
 import { NumberUtils } from '../../utils/NumberUtils';
 import { Utils } from '../../utils/Utils';
 
+@injectFromBase()
 @injectable()
 export class HexadecimalIdentifierNamesGenerator extends AbstractIdentifierNamesGenerator {
     /**

--- a/src/generators/identifier-names-generators/MangledIdentifierNamesGenerator.ts
+++ b/src/generators/identifier-names-generators/MangledIdentifierNamesGenerator.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TNodeWithLexicalScope } from '../../types/node/TNodeWithLexicalScope';
@@ -15,6 +15,7 @@ import { reservedIdentifierNames } from '../../constants/ReservedIdentifierNames
 import { AbstractIdentifierNamesGenerator } from './AbstractIdentifierNamesGenerator';
 import { NodeLexicalScopeUtils } from '../../node/NodeLexicalScopeUtils';
 
+@injectFromBase()
 @injectable()
 export class MangledIdentifierNamesGenerator extends AbstractIdentifierNamesGenerator {
     /**

--- a/src/generators/identifier-names-generators/MangledShuffledIdentifierNamesGenerator.ts
+++ b/src/generators/identifier-names-generators/MangledShuffledIdentifierNamesGenerator.ts
@@ -1,4 +1,4 @@
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable, injectFromBase, postConstruct } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { IArrayUtils } from '../../interfaces/utils/IArrayUtils';
@@ -12,6 +12,7 @@ import { alphabetStringUppercase } from '../../constants/AlphabetStringUppercase
 
 import { MangledIdentifierNamesGenerator } from './MangledIdentifierNamesGenerator';
 
+@injectFromBase()
 @injectable()
 export class MangledShuffledIdentifierNamesGenerator extends MangledIdentifierNamesGenerator {
     /**

--- a/src/interfaces/container/IInversifyContainerFacade.ts
+++ b/src/interfaces/container/IInversifyContainerFacade.ts
@@ -1,4 +1,4 @@
-import { interfaces } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { TInputOptions } from '../../types/options/TInputOptions';
 
@@ -6,13 +6,13 @@ export interface IInversifyContainerFacade {
     /**
      * @param serviceIdentifier
      */
-    get<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): T;
+    get<T>(serviceIdentifier: ServiceIdentifier<T>): T;
 
     /**
      * @param serviceIdentifier
      * @param named
      */
-    getNamed<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): T;
+    getNamed<T>(serviceIdentifier: ServiceIdentifier<T>, named: string | number | symbol): T;
 
     /**
      * @param {string} sourceCode

--- a/src/node-transformers/NodeTransformerNamesGroupsBuilder.ts
+++ b/src/node-transformers/NodeTransformerNamesGroupsBuilder.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { injectable, injectFromBase } from 'inversify';
 
 import { INodeTransformer } from '../interfaces/node-transformers/INodeTransformer';
 
@@ -6,6 +6,7 @@ import { NodeTransformer } from '../enums/node-transformers/NodeTransformer';
 
 import { AbstractTransformerNamesGroupsBuilder } from '../utils/AbstractTransformerNamesGroupsBuilder';
 
+@injectFromBase()
 @injectable()
 export class NodeTransformerNamesGroupsBuilder extends AbstractTransformerNamesGroupsBuilder<
     NodeTransformer,

--- a/src/node-transformers/control-flow-transformers/BlockStatementControlFlowTransformer.ts
+++ b/src/node-transformers/control-flow-transformers/BlockStatementControlFlowTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -22,6 +22,7 @@ import { BlockStatementControlFlowFlatteningNode } from '../../custom-nodes/cont
 import { NodeGuards } from '../../node/NodeGuards';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class BlockStatementControlFlowTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/control-flow-transformers/FunctionControlFlowTransformer.ts
+++ b/src/node-transformers/control-flow-transformers/FunctionControlFlowTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -31,6 +31,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 import { NodeStatementUtils } from '../../node/NodeStatementUtils';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class FunctionControlFlowTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/control-flow-transformers/StringArrayControlFlowTransformer.ts
+++ b/src/node-transformers/control-flow-transformers/StringArrayControlFlowTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -23,6 +23,7 @@ import { NodeTransformer } from '../../enums/node-transformers/NodeTransformer';
 import { FunctionControlFlowTransformer } from './FunctionControlFlowTransformer';
 import { NodeGuards } from '../../node/NodeGuards';
 
+@injectFromBase()
 @injectable()
 export class StringArrayControlFlowTransformer extends FunctionControlFlowTransformer {
     /**

--- a/src/node-transformers/control-flow-transformers/control-flow-replacers/BinaryExpressionControlFlowReplacer.ts
+++ b/src/node-transformers/control-flow-transformers/control-flow-replacers/BinaryExpressionControlFlowReplacer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -17,6 +17,7 @@ import { ControlFlowCustomNode } from '../../../enums/custom-nodes/ControlFlowCu
 import { BinaryExpressionFunctionNode } from '../../../custom-nodes/control-flow-flattening-nodes/BinaryExpressionFunctionNode';
 import { ExpressionWithOperatorControlFlowReplacer } from './ExpressionWithOperatorControlFlowReplacer';
 
+@injectFromBase()
 @injectable()
 export class BinaryExpressionControlFlowReplacer extends ExpressionWithOperatorControlFlowReplacer {
     /**

--- a/src/node-transformers/control-flow-transformers/control-flow-replacers/CallExpressionControlFlowReplacer.ts
+++ b/src/node-transformers/control-flow-transformers/control-flow-replacers/CallExpressionControlFlowReplacer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -20,6 +20,7 @@ import { CallExpressionFunctionNode } from '../../../custom-nodes/control-flow-f
 import { CallExpressionControlFlowStorageCallNode } from '../../../custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/CallExpressionControlFlowStorageCallNode';
 import { NodeGuards } from '../../../node/NodeGuards';
 
+@injectFromBase()
 @injectable()
 export class CallExpressionControlFlowReplacer extends AbstractControlFlowReplacer {
     /**

--- a/src/node-transformers/control-flow-transformers/control-flow-replacers/ExpressionWithOperatorControlFlowReplacer.ts
+++ b/src/node-transformers/control-flow-transformers/control-flow-replacers/ExpressionWithOperatorControlFlowReplacer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -18,6 +18,7 @@ import { AbstractControlFlowReplacer } from './AbstractControlFlowReplacer';
 import { ExpressionWithOperatorControlFlowStorageCallNode } from '../../../custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/ExpressionWithOperatorControlFlowStorageCallNode';
 import { NodeGuards } from '../../../node/NodeGuards';
 
+@injectFromBase()
 @injectable()
 export abstract class ExpressionWithOperatorControlFlowReplacer extends AbstractControlFlowReplacer {
     /**

--- a/src/node-transformers/control-flow-transformers/control-flow-replacers/LogicalExpressionControlFlowReplacer.ts
+++ b/src/node-transformers/control-flow-transformers/control-flow-replacers/LogicalExpressionControlFlowReplacer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -20,6 +20,7 @@ import { LogicalExpressionFunctionNode } from '../../../custom-nodes/control-flo
 import { NodeGuards } from '../../../node/NodeGuards';
 import { NodeUtils } from '../../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class LogicalExpressionControlFlowReplacer extends ExpressionWithOperatorControlFlowReplacer {
     /**

--- a/src/node-transformers/control-flow-transformers/control-flow-replacers/StringArrayCallControlFlowReplacer.ts
+++ b/src/node-transformers/control-flow-transformers/control-flow-replacers/StringArrayCallControlFlowReplacer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -22,6 +22,7 @@ import { NodeMetadata } from '../../../node/NodeMetadata';
 import { StringLiteralControlFlowStorageCallNode } from '../../../custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/StringLiteralControlFlowStorageCallNode';
 import { LiteralNode } from '../../../custom-nodes/control-flow-flattening-nodes/LiteralNode';
 
+@injectFromBase()
 @injectable()
 export class StringArrayCallControlFlowReplacer extends AbstractControlFlowReplacer {
     /**

--- a/src/node-transformers/control-flow-transformers/control-flow-replacers/StringLiteralControlFlowReplacer.ts
+++ b/src/node-transformers/control-flow-transformers/control-flow-replacers/StringLiteralControlFlowReplacer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -21,6 +21,7 @@ import { NodeLiteralUtils } from '../../../node/NodeLiteralUtils';
 import { StringLiteralControlFlowStorageCallNode } from '../../../custom-nodes/control-flow-flattening-nodes/control-flow-storage-nodes/StringLiteralControlFlowStorageCallNode';
 import { LiteralNode } from '../../../custom-nodes/control-flow-flattening-nodes/LiteralNode';
 
+@injectFromBase()
 @injectable()
 export class StringLiteralControlFlowReplacer extends AbstractControlFlowReplacer {
     /**

--- a/src/node-transformers/converting-transformers/BooleanLiteralTransformer.ts
+++ b/src/node-transformers/converting-transformers/BooleanLiteralTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -14,6 +14,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 import { NodeUtils } from '../../node/NodeUtils';
 import { NodeFactory } from '../../node/NodeFactory';
 
+@injectFromBase()
 @injectable()
 export class BooleanLiteralTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/ClassFieldTransformer.ts
+++ b/src/node-transformers/converting-transformers/ClassFieldTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -29,6 +29,7 @@ import { IdentifierReplacer } from '../rename-identifiers-transformers/replacer/
  *
  * Literal node will be obfuscated by LiteralTransformer
  */
+@injectFromBase()
 @injectable()
 export class ClassFieldTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/ExportSpecifierTransformer.ts
+++ b/src/node-transformers/converting-transformers/ExportSpecifierTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -13,6 +13,7 @@ import { AbstractNodeTransformer } from '../AbstractNodeTransformer';
 import { NodeGuards } from '../../node/NodeGuards';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class ExportSpecifierTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/MemberExpressionTransformer.ts
+++ b/src/node-transformers/converting-transformers/MemberExpressionTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -14,6 +14,7 @@ import { NodeFactory } from '../../node/NodeFactory';
 import { NodeGuards } from '../../node/NodeGuards';
 import { NodeMetadata } from '../../node/NodeMetadata';
 
+@injectFromBase()
 @injectable()
 export class MemberExpressionTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/NumberLiteralTransformer.ts
+++ b/src/node-transformers/converting-transformers/NumberLiteralTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -15,6 +15,7 @@ import { NodeFactory } from '../../node/NodeFactory';
 import { NodeGuards } from '../../node/NodeGuards';
 import { NumberUtils } from '../../utils/NumberUtils';
 
+@injectFromBase()
 @injectable()
 export class NumberLiteralTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/NumberToNumericalExpressionTransformer.ts
+++ b/src/node-transformers/converting-transformers/NumberToNumericalExpressionTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -26,6 +26,7 @@ import { NumericalExpressionDataToNodeConverter } from '../../node/NumericalExpr
  * on:
  *     var number = 50 + (100 * 2) - 127;
  */
+@injectFromBase()
 @injectable()
 export class NumberToNumericalExpressionTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/ObjectExpressionKeysTransformer.ts
+++ b/src/node-transformers/converting-transformers/ObjectExpressionKeysTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -17,6 +17,7 @@ import { AbstractNodeTransformer } from '../AbstractNodeTransformer';
 import { NodeGuards } from '../../node/NodeGuards';
 import { NodeStatementUtils } from '../../node/NodeStatementUtils';
 
+@injectFromBase()
 @injectable()
 export class ObjectExpressionKeysTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/ObjectExpressionTransformer.ts
+++ b/src/node-transformers/converting-transformers/ObjectExpressionTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -20,6 +20,7 @@ import { NodeGuards } from '../../node/NodeGuards';
  * on:
  *     var object = { 'PSEUDO': 1 };
  */
+@injectFromBase()
 @injectable()
 export class ObjectExpressionTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/ObjectPatternPropertiesTransformer.ts
+++ b/src/node-transformers/converting-transformers/ObjectPatternPropertiesTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -16,6 +16,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 import { NodeLexicalScopeUtils } from '../../node/NodeLexicalScopeUtils';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class ObjectPatternPropertiesTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/SplitStringTransformer.ts
+++ b/src/node-transformers/converting-transformers/SplitStringTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -21,6 +21,7 @@ import { NodeUtils } from '../../node/NodeUtils';
 /**
  * Splits strings into parts
  */
+@injectFromBase()
 @injectable()
 export class SplitStringTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/converting-transformers/TemplateLiteralTransformer.ts
+++ b/src/node-transformers/converting-transformers/TemplateLiteralTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -18,6 +18,7 @@ import { NodeUtils } from '../../node/NodeUtils';
  * Transform ES2015 template literals to ES5
  * Thanks to Babel for algorithm
  */
+@injectFromBase()
 @injectable()
 export class TemplateLiteralTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/dead-code-injection-transformers/DeadCodeInjectionIdentifiersTransformer.ts
+++ b/src/node-transformers/dead-code-injection-transformers/DeadCodeInjectionIdentifiersTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as eslintScope from 'eslint-scope';
@@ -21,6 +21,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 /**
  * Renames all scope through identifiers for Dead Code Injection
  */
+@injectFromBase()
 @injectable()
 export class DeadCodeInjectionIdentifiersTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/dead-code-injection-transformers/DeadCodeInjectionTransformer.ts
+++ b/src/node-transformers/dead-code-injection-transformers/DeadCodeInjectionTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -27,6 +27,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 import { NodeStatementUtils } from '../../node/NodeStatementUtils';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class DeadCodeInjectionTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/finalizing-transformers/DirectivePlacementTransformer.ts
+++ b/src/node-transformers/finalizing-transformers/DirectivePlacementTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -23,6 +23,7 @@ import { NodeUtils } from '../../node/NodeUtils';
  * It's easier to fix "use strict"; placement after obfuscation as a separate stage
  * than ignore this directive in other transformers like control flow and dead code injection transformers
  */
+@injectFromBase()
 @injectable()
 export class DirectivePlacementTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/finalizing-transformers/EscapeSequenceTransformer.ts
+++ b/src/node-transformers/finalizing-transformers/EscapeSequenceTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -17,6 +17,7 @@ import { NodeLiteralUtils } from '../../node/NodeLiteralUtils';
 import { NodeFactory } from '../../node/NodeFactory';
 import { NodeUtils } from '../../node/NodeUtils';
 
+@injectFromBase()
 @injectable()
 export class EscapeSequenceTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/initializing-transformers/CommentsTransformer.ts
+++ b/src/node-transformers/initializing-transformers/CommentsTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -14,6 +14,7 @@ import { AbstractNodeTransformer } from '../AbstractNodeTransformer';
 import { ConditionalCommentObfuscatingGuard } from '../preparing-transformers/obfuscating-guards/ConditionalCommentObfuscatingGuard';
 import { NodeGuards } from '../../node/NodeGuards';
 
+@injectFromBase()
 @injectable()
 export class CommentsTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/preparing-transformers/CustomCodeHelpersTransformer.ts
+++ b/src/node-transformers/preparing-transformers/CustomCodeHelpersTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -23,6 +23,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 /**
  * Analyzing AST-tree and appending custom code helpers
  */
+@injectFromBase()
 @injectable()
 export class CustomCodeHelpersTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/preparing-transformers/EvalCallExpressionTransformer.ts
+++ b/src/node-transformers/preparing-transformers/EvalCallExpressionTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -17,6 +17,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 import { NodeUtils } from '../../node/NodeUtils';
 import { StringUtils } from '../../utils/StringUtils';
 
+@injectFromBase()
 @injectable()
 export class EvalCallExpressionTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/preparing-transformers/MetadataTransformer.ts
+++ b/src/node-transformers/preparing-transformers/MetadataTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -17,6 +17,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 /**
  * Adds metadata properties to each node
  */
+@injectFromBase()
 @injectable()
 export class MetadataTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/preparing-transformers/ObfuscatingGuardsTransformer.ts
+++ b/src/node-transformers/preparing-transformers/ObfuscatingGuardsTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -22,6 +22,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 /**
  * Adds `ignoredNode` properties to each node
  */
+@injectFromBase()
 @injectable()
 export class ObfuscatingGuardsTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/preparing-transformers/ParentificationTransformer.ts
+++ b/src/node-transformers/preparing-transformers/ParentificationTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -15,6 +15,7 @@ import { NodeUtils } from '../../node/NodeUtils';
 /**
  * Adds `parentNode` properties to each node
  */
+@injectFromBase()
 @injectable()
 export class ParentificationTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/preparing-transformers/VariablePreserveTransformer.ts
+++ b/src/node-transformers/preparing-transformers/VariablePreserveTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import * as ESTree from 'estree';
 import * as eslintScope from 'eslint-scope';
 
@@ -21,6 +21,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 /**
  * Preserve non-replaceable variables
  */
+@injectFromBase()
 @injectable()
 export class VariablePreserveTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/rename-identifiers-transformers/LabeledStatementTransformer.ts
+++ b/src/node-transformers/rename-identifiers-transformers/LabeledStatementTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -33,6 +33,7 @@ import { NodeLexicalScopeUtils } from '../../node/NodeLexicalScopeUtils';
  *     }
  *
  */
+@injectFromBase()
 @injectable()
 export class LabeledStatementTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/rename-identifiers-transformers/ScopeIdentifiersTransformer.ts
+++ b/src/node-transformers/rename-identifiers-transformers/ScopeIdentifiersTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as eslintScope from 'eslint-scope';
@@ -23,6 +23,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 /**
  * Replaces all replaceable identifiers in scope
  */
+@injectFromBase()
 @injectable()
 export class ScopeIdentifiersTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/rename-identifiers-transformers/ScopeThroughIdentifiersTransformer.ts
+++ b/src/node-transformers/rename-identifiers-transformers/ScopeThroughIdentifiersTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as eslintScope from 'eslint-scope';
@@ -21,6 +21,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 /**
  * Renames all through identifiers
  */
+@injectFromBase()
 @injectable()
 export class ScopeThroughIdentifiersTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/rename-properties-transformers/RenamePropertiesTransformer.ts
+++ b/src/node-transformers/rename-properties-transformers/RenamePropertiesTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -16,6 +16,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 import { NodeLiteralUtils } from '../../node/NodeLiteralUtils';
 import { NodeMetadata } from '../../node/NodeMetadata';
 
+@injectFromBase()
 @injectable()
 export class RenamePropertiesTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/simplifying-transformers/AbstractStatementSimplifyTransformer.ts
+++ b/src/node-transformers/simplifying-transformers/AbstractStatementSimplifyTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -17,6 +17,7 @@ import { NodeFactory } from '../../node/NodeFactory';
 /**
  * Simplifies `Statement` node
  */
+@injectFromBase()
 @injectable()
 export abstract class AbstractStatementSimplifyTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/simplifying-transformers/BlockStatementSimplifyTransformer.ts
+++ b/src/node-transformers/simplifying-transformers/BlockStatementSimplifyTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -19,6 +19,7 @@ import { NodeUtils } from '../../node/NodeUtils';
 /**
  * Simplifies `BlockStatement` node
  */
+@injectFromBase()
 @injectable()
 export class BlockStatementSimplifyTransformer extends AbstractStatementSimplifyTransformer {
     /**

--- a/src/node-transformers/simplifying-transformers/ExpressionStatementsMergeTransformer.ts
+++ b/src/node-transformers/simplifying-transformers/ExpressionStatementsMergeTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -26,6 +26,7 @@ import { NodeUtils } from '../../node/NodeUtils';
  * on:
  *     (console.log(1), console.log(2));
  */
+@injectFromBase()
 @injectable()
 export class ExpressionStatementsMergeTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/simplifying-transformers/IfStatementSimplifyTransformer.ts
+++ b/src/node-transformers/simplifying-transformers/IfStatementSimplifyTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -18,6 +18,7 @@ import { NodeUtils } from '../../node/NodeUtils';
 /**
  * Simplifies `IfStatement` node
  */
+@injectFromBase()
 @injectable()
 export class IfStatementSimplifyTransformer extends AbstractStatementSimplifyTransformer {
     /**

--- a/src/node-transformers/simplifying-transformers/VariableDeclarationsMergeTransformer.ts
+++ b/src/node-transformers/simplifying-transformers/VariableDeclarationsMergeTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -25,6 +25,7 @@ import { NodeStatementUtils } from '../../node/NodeStatementUtils';
  *     var foo = 1,
  *         bar = 2;
  */
+@injectFromBase()
 @injectable()
 export class VariableDeclarationsMergeTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/string-array-transformers/StringArrayRotateFunctionTransformer.ts
+++ b/src/node-transformers/string-array-transformers/StringArrayRotateFunctionTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as estraverse from '@javascript-obfuscator/estraverse';
@@ -33,6 +33,7 @@ import { NodeUtils } from '../../node/NodeUtils';
 import { NumericalExpressionDataToNodeConverter } from '../../node/NumericalExpressionDataToNodeConverter';
 import { StringArrayRotateFunctionCodeHelper } from '../../custom-code-helpers/string-array/StringArrayRotateFunctionCodeHelper';
 
+@injectFromBase()
 @injectable()
 export class StringArrayRotateFunctionTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/string-array-transformers/StringArrayScopeCallsWrapperTransformer.ts
+++ b/src/node-transformers/string-array-transformers/StringArrayScopeCallsWrapperTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -30,6 +30,7 @@ import { NodeGuards } from '../../node/NodeGuards';
 import { StringArrayScopeCallsWrapperFunctionNode } from '../../custom-nodes/string-array-nodes/StringArrayScopeCallsWrapperFunctionNode';
 import { StringArrayScopeCallsWrapperVariableNode } from '../../custom-nodes/string-array-nodes/StringArrayScopeCallsWrapperVariableNode';
 
+@injectFromBase()
 @injectable()
 export class StringArrayScopeCallsWrapperTransformer extends AbstractNodeTransformer {
     /**

--- a/src/node-transformers/string-array-transformers/StringArrayTransformer.ts
+++ b/src/node-transformers/string-array-transformers/StringArrayTransformer.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -36,6 +36,7 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 import { NodeUtils } from '../../node/NodeUtils';
 import { StringArrayCallNode } from '../../custom-nodes/string-array-nodes/StringArrayCallNode';
 
+@injectFromBase()
 @injectable()
 export class StringArrayTransformer extends AbstractNodeTransformer {
     /**

--- a/src/storages/control-flow-transformers/FunctionControlFlowStorage.ts
+++ b/src/storages/control-flow-transformers/FunctionControlFlowStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -11,6 +11,7 @@ import { IRandomGenerator } from '../../interfaces/utils/IRandomGenerator';
 
 import { MapStorage } from '../MapStorage';
 
+@injectFromBase()
 @injectable()
 export class FunctionControlFlowStorage extends MapStorage<string, ICustomNode> implements IControlFlowStorage {
     /**

--- a/src/storages/control-flow-transformers/StringControlFlowStorage.ts
+++ b/src/storages/control-flow-transformers/StringControlFlowStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -8,6 +8,7 @@ import { IRandomGenerator } from '../../interfaces/utils/IRandomGenerator';
 
 import { FunctionControlFlowStorage } from './FunctionControlFlowStorage';
 
+@injectFromBase()
 @injectable()
 export class StringControlFlowStorage extends FunctionControlFlowStorage {
     /**

--- a/src/storages/custom-code-helpers/CustomCodeHelperGroupStorage.ts
+++ b/src/storages/custom-code-helpers/CustomCodeHelperGroupStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable, injectFromBase, postConstruct } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TCustomCodeHelperGroupFactory } from '../../types/container/custom-code-helpers/TCustomCodeHelperGroupFactory';
@@ -11,6 +11,7 @@ import { CustomCodeHelperGroup } from '../../enums/custom-code-helpers/CustomCod
 
 import { MapStorage } from '../MapStorage';
 
+@injectFromBase()
 @injectable()
 export class CustomCodeHelperGroupStorage extends MapStorage<string, ICustomCodeHelperGroup> {
     /**

--- a/src/storages/identifier-names-cache/GlobalIdentifierNamesCacheStorage.ts
+++ b/src/storages/identifier-names-cache/GlobalIdentifierNamesCacheStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable, injectFromBase, postConstruct } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { IGlobalIdentifierNamesCacheStorage } from '../../interfaces/storages/identifier-names-cache/IGlobalIdentifierNamesCacheStorage';
@@ -7,6 +7,7 @@ import { IRandomGenerator } from '../../interfaces/utils/IRandomGenerator';
 
 import { MapStorage } from '../MapStorage';
 
+@injectFromBase()
 @injectable()
 export class GlobalIdentifierNamesCacheStorage
     extends MapStorage<string, string>

--- a/src/storages/identifier-names-cache/PropertyIdentifierNamesCacheStorage.ts
+++ b/src/storages/identifier-names-cache/PropertyIdentifierNamesCacheStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable, injectFromBase, postConstruct } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { IOptions } from '../../interfaces/options/IOptions';
@@ -7,6 +7,7 @@ import { IRandomGenerator } from '../../interfaces/utils/IRandomGenerator';
 
 import { MapStorage } from '../MapStorage';
 
+@injectFromBase()
 @injectable()
 export class PropertyIdentifierNamesCacheStorage
     extends MapStorage<string, string>

--- a/src/storages/string-array-transformers/LiteralNodesCacheStorage.ts
+++ b/src/storages/string-array-transformers/LiteralNodesCacheStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import * as ESTree from 'estree';
@@ -12,6 +12,7 @@ import { StringArrayEncoding } from '../../enums/node-transformers/string-array-
 
 import { MapStorage } from '../MapStorage';
 
+@injectFromBase()
 @injectable()
 export class LiteralNodesCacheStorage extends MapStorage<string, ESTree.Node> implements ILiteralNodesCacheStorage {
     /**

--- a/src/storages/string-array-transformers/StringArrayScopeCallsWrappersDataStorage.ts
+++ b/src/storages/string-array-transformers/StringArrayScopeCallsWrappersDataStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TNodeWithLexicalScopeStatements } from '../../types/node/TNodeWithLexicalScopeStatements';
@@ -10,6 +10,7 @@ import { IStringArrayScopeCallsWrappersDataStorage } from '../../interfaces/stor
 
 import { WeakMapStorage } from '../WeakMapStorage';
 
+@injectFromBase()
 @injectable()
 export class StringArrayScopeCallsWrappersDataStorage
     extends WeakMapStorage<TNodeWithLexicalScopeStatements, TStringArrayScopeCallsWrappersDataByEncoding>

--- a/src/storages/string-array-transformers/StringArrayStorage.ts
+++ b/src/storages/string-array-transformers/StringArrayStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable, injectFromBase, postConstruct } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TIdentifierNamesGeneratorFactory } from '../../types/container/generators/TIdentifierNamesGeneratorFactory';
@@ -17,6 +17,7 @@ import { StringArrayEncoding } from '../../enums/node-transformers/string-array-
 
 import { MapStorage } from '../MapStorage';
 
+@injectFromBase()
 @injectable()
 export class StringArrayStorage
     extends MapStorage<`${string}-${TStringArrayEncoding}`, IStringArrayStorageItemData>

--- a/src/storages/string-array-transformers/VisitedLexicalScopeNodesStackStorage.ts
+++ b/src/storages/string-array-transformers/VisitedLexicalScopeNodesStackStorage.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../../container/ServiceIdentifiers';
 
 import { TNodeWithLexicalScopeStatements } from '../../types/node/TNodeWithLexicalScopeStatements';
@@ -10,6 +10,7 @@ import { IVisitedLexicalScopeNodesStackStorage } from '../../interfaces/storages
 
 import { ArrayStorage } from '../ArrayStorage';
 
+@injectFromBase()
 @injectable()
 export class VisitedLexicalScopeNodesStackStorage
     extends ArrayStorage<TNodeWithLexicalScopeStatements>

--- a/src/utils/CryptUtilsStringArray.ts
+++ b/src/utils/CryptUtilsStringArray.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, injectFromBase } from 'inversify';
 import { ServiceIdentifiers } from '../container/ServiceIdentifiers';
 
 import { ICryptUtilsStringArray } from '../interfaces/utils/ICryptUtilsStringArray';
@@ -8,6 +8,7 @@ import { base64alphabetSwapped } from '../constants/Base64AlphabetSwapped';
 
 import { CryptUtils } from './CryptUtils';
 
+@injectFromBase()
 @injectable()
 export class CryptUtilsStringArray extends CryptUtils implements ICryptUtilsStringArray {
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,23 +260,46 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@inversifyjs/common@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/common/-/common-1.3.3.tgz#c34bba10be8c511bf3cd25473bd32c2a08987111"
-  integrity sha512-ZH0wrgaJwIo3s9gMCDM2wZoxqrJ6gB97jWXncROfYdqZJv8f3EkqT57faZqN5OTeHWgtziQ6F6g3L8rCvGceCw==
+"@inversifyjs/common@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/common/-/common-1.5.2.tgz#6836287fef1c25dddbdf6af345a33a6d6caf6835"
+  integrity sha512-WlzR9xGadABS9gtgZQ+luoZ8V6qm4Ii6RQfcfC9Ho2SOlE6ZuemFo7PKJvKI0ikm8cmKbU8hw5UK6E4qovH21w==
 
-"@inversifyjs/core@1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/core/-/core-1.3.4.tgz#17d2614ff48fc6e0db20c2fe3258c3d5bef9b5e0"
-  integrity sha512-gCCmA4BdbHEFwvVZ2elWgHuXZWk6AOu/1frxsS+2fWhjEk2c/IhtypLo5ytSUie1BCiT6i9qnEo4bruBomQsAA==
+"@inversifyjs/container@1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/container/-/container-1.15.0.tgz#e92e2a881f5300f373a855fd74aa8280dc863825"
+  integrity sha512-U2xYsPrJTz5za2TExi5lg8qOWf8TEVBpN+pQM7B8BVA2rajtbRE9A66SLRHk8c1eGXmg+0K4Hdki6tWAsSQBUA==
   dependencies:
-    "@inversifyjs/common" "1.3.3"
-    "@inversifyjs/reflect-metadata-utils" "0.2.3"
+    "@inversifyjs/common" "1.5.2"
+    "@inversifyjs/core" "9.2.0"
+    "@inversifyjs/plugin" "0.2.0"
+    "@inversifyjs/reflect-metadata-utils" "1.4.1"
 
-"@inversifyjs/reflect-metadata-utils@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.3.tgz#b17359fd4fdfc85726d3b1af7ad3647136950ea0"
-  integrity sha512-d3D0o9TeSlvaGM2I24wcNw/Aj3rc4OYvHXOKDC09YEph5fMMiKd6fq1VTQd9tOkDNWvVbw+cnt45Wy9P/t5Lvw==
+"@inversifyjs/core@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/core/-/core-9.2.0.tgz#f587ccb917c82698ac0f9ceb2a544af42acff36f"
+  integrity sha512-Nm7BR6KmpgshIHpVQWuEDehqRVb6GBm8LFEuhc2s4kSZWrArZ15RmXQzROLk4m+hkj4kMXgvMm5Qbopot/D6Sg==
+  dependencies:
+    "@inversifyjs/common" "1.5.2"
+    "@inversifyjs/prototype-utils" "0.1.3"
+    "@inversifyjs/reflect-metadata-utils" "1.4.1"
+
+"@inversifyjs/plugin@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/plugin/-/plugin-0.2.0.tgz#03957c7d02803f32254a2ff2f8f8ffb05ec57eec"
+  integrity sha512-R/JAdkTSD819pV1zi0HP54mWHyX+H2m8SxldXRgPQarS3ySV4KPyRdosWcfB8Se0JJZWZLHYiUNiS6JvMWSPjw==
+
+"@inversifyjs/prototype-utils@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/prototype-utils/-/prototype-utils-0.1.3.tgz#c720e7d2d847e4748534c5986b25e271186898d2"
+  integrity sha512-EzRamZzNgE9Sn3QtZ8NncNa2lpPMZfspqbK6BWFguWnOpK8ymp2TUuH46ruFHZhrHKnknPd7fG22ZV7iF517TQ==
+  dependencies:
+    "@inversifyjs/common" "1.5.2"
+
+"@inversifyjs/reflect-metadata-utils@1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.4.1.tgz#6219df487e6aab1810a0feee4a625a0e11397340"
+  integrity sha512-Cp77C4d2wLaHXiUB7iH6Cxb7i1lD/YDuTIHLTDzKINqGSz0DCSoL/Dg2wVkW/6Qx03r/yQMLJ+32Agl32N2X8g==
 
 "@isaacs/balanced-match@^4.0.1":
   version "4.0.1"
@@ -3042,13 +3065,14 @@ interpret@^3.1.1:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
   integrity sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==
 
-inversify@6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.1.4.tgz#7dc288b190bc6c0e2081d7a003cbf6c4f94d946f"
-  integrity sha512-PbxrZH/gTa1fpPEEGAjJQzK8tKMIp5gRg6EFNJlCtzUcycuNdmhv3uk5P8Itm/RIjgHJO16oQRLo9IHzQN51bA==
+inversify@7.11.0:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-7.11.0.tgz#571cede6346081b5af224eaea49bb97a91268f92"
+  integrity sha512-yZDprSSr8TyVeMGI/AOV4ws6gwjX22hj9Z8/oHAVpJORY6WRFTcUzhnZtibBUHEw2U8ArvHcR+i863DplQ3Cwg==
   dependencies:
-    "@inversifyjs/common" "1.3.3"
-    "@inversifyjs/core" "1.3.4"
+    "@inversifyjs/common" "1.5.2"
+    "@inversifyjs/container" "1.15.0"
+    "@inversifyjs/core" "9.2.0"
 
 is-arguments@^1.0.4:
   version "1.0.4"
@@ -4921,8 +4945,7 @@ string-template@1.0.0:
   resolved "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz"
   integrity sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4939,6 +4962,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -5020,7 +5052,7 @@ stringz@2.1.0:
   dependencies:
     char-regex "^1.0.2"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5033,6 +5065,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.2"


### PR DESCRIPTION
Migrate the dependency injection framework from Inversify v6 to v7. This is a breaking change in the Inversify API that requires updates throughout the codebase.

Key changes:

- Update inversify dependency from 6.1.4 to 7.11.0
- Replace `interfaces.Bind` with `ContainerModuleLoadOptions` in all container modules
- Change `bind` parameter to `options` in ContainerModule callbacks
- Update method calls from `bind()` to `options.bind()`
- Replace `whenTargetNamed()` with `whenNamed()`
- Import `ContainerModuleLoadOptions` instead of `interfaces` from inversify
- Add `injectFromBase` decorator to all injectable classes that extend from base classes
- Update factory types to use `Factory<T, [Args]>` and `ResolutionContext` instead of `interfaces.Context`
- Replace `interfaces.ServiceIdentifier<T>` with `ServiceIdentifier<T>`
- Update `context.container.getNamed()` to `context.get()` with options object in factory bindings

All container modules, custom code helpers, custom nodes, generators, node transformers, and storage classes have been updated to be compatible with the new Inversify v7 API.