### PR TITLE
Fixed parsing error when `await` is used as an identifier in non-async context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Change Log
 v5.2.1
 ---
 * Fixed `transformObjectKeys` incorrectly hoisting object literal outside of loop when loop body is a single statement without braces, causing all iterations to share the same object reference. Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1300
+* Fixed parsing error when `await` is used as an identifier in non-async context. Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1127
 
 v5.2.0
 ---

--- a/src/ASTParserFacade.ts
+++ b/src/ASTParserFacade.ts
@@ -58,7 +58,11 @@ export class ASTParserFacade {
         const comments: ESTree.Comment[] = [];
         const config: acorn.Options = {
             ...inputConfig,
-            allowAwaitOutsideFunction: true,
+            allowAwaitOutsideFunction: false,
+            allowReserved: true,
+            allowImportExportEverywhere: true,
+            allowReturnOutsideFunction: true,
+            allowSuperOutsideMethod: true,
             onComment: comments,
             sourceType
         };

--- a/test/functional-tests/issues/fixtures/issue1127-top-level-await.js
+++ b/test/functional-tests/issues/fixtures/issue1127-top-level-await.js
@@ -1,0 +1,2 @@
+const x = await Promise.resolve(1);
+console.log(x);

--- a/test/functional-tests/issues/fixtures/issue1127.js
+++ b/test/functional-tests/issues/fixtures/issue1127.js
@@ -1,0 +1,1 @@
+try { await; } catch { console.log('caught'); }

--- a/test/functional-tests/issues/issue1127.spec.ts
+++ b/test/functional-tests/issues/issue1127.spec.ts
@@ -1,0 +1,43 @@
+import { assert } from 'chai';
+import { NO_ADDITIONAL_NODES_PRESET } from '../../../src/options/presets/NoCustomNodes';
+import { readFileAsString } from '../../helpers/readFileAsString';
+import { JavaScriptObfuscator } from '../../../src/JavaScriptObfuscatorFacade';
+
+//
+// https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1127
+//
+describe('Issue #1127', () => {
+    describe('`await` used as identifier should not crash', () => {
+        let testFunc: () => string;
+
+        before(() => {
+            const code: string = readFileAsString(__dirname + '/fixtures/issue1127.js');
+
+            testFunc = () =>
+                JavaScriptObfuscator.obfuscate(code, {
+                    ...NO_ADDITIONAL_NODES_PRESET
+                }).getObfuscatedCode();
+        });
+
+        it('does not crash on obfuscating', () => {
+            assert.doesNotThrow(testFunc);
+        });
+    });
+
+    describe('top-level await should still work', () => {
+        let testFunc: () => string;
+
+        before(() => {
+            const code: string = readFileAsString(__dirname + '/fixtures/issue1127-top-level-await.js');
+
+            testFunc = () =>
+                JavaScriptObfuscator.obfuscate(code, {
+                    ...NO_ADDITIONAL_NODES_PRESET
+                }).getObfuscatedCode();
+        });
+
+        it('does not crash on obfuscating', () => {
+            assert.doesNotThrow(testFunc);
+        });
+    });
+});


### PR DESCRIPTION
Fixed parsing error when `await` is used as an identifier in non-async context