### PR TITLE
Reuse scope analysis between identifier transformers

### DIFF
--- a/src/analyzers/scope-analyzer/ScopeAnalyzer.ts
+++ b/src/analyzers/scope-analyzer/ScopeAnalyzer.ts
@@ -41,6 +41,11 @@ export class ScopeAnalyzer implements IScopeAnalyzer {
     private scopeManager: eslintScope.ScopeManager | null = null;
 
     /**
+     * @type {eslintScope.ScopeManager | null}
+     */
+    private sanitizedScopeManager: eslintScope.ScopeManager | null = null;
+
+    /**
      * `eslint-scope` reads `ranges` property of a nodes
      * Should attach that property to the some custom nodes
      *
@@ -74,6 +79,9 @@ export class ScopeAnalyzer implements IScopeAnalyzer {
      */
     public analyze(astTree: ESTree.Node): void {
         const sourceTypeLength: number = ScopeAnalyzer.sourceTypes.length;
+
+        this.scopeManager = null;
+        this.sanitizedScopeManager = null;
 
         ScopeAnalyzer.attachMissingRanges(astTree);
 
@@ -117,9 +125,23 @@ export class ScopeAnalyzer implements IScopeAnalyzer {
             throw new Error('Cannot acquire scope for node');
         }
 
-        this.sanitizeScopes(scope);
+        if (this.sanitizedScopeManager !== this.scopeManager) {
+            this.sanitizeScopes(scope);
+            this.sanitizedScopeManager = this.scopeManager;
+        }
 
         return scope;
+    }
+
+    /**
+     * Checks whether a scope for the given node is already available in the current
+     * scope manager (i.e. `analyze` has been run for the tree this node belongs to).
+     *
+     * @param {Node} node
+     * @returns {boolean}
+     */
+    public isAnalyzed(node: ESTree.Node): boolean {
+        return !!this.scopeManager?.acquire(node, ScopeAnalyzer.isRootNode(node));
     }
 
     /**

--- a/src/interfaces/analyzers/scope-analyzer/IScopeAnalyzer.ts
+++ b/src/interfaces/analyzers/scope-analyzer/IScopeAnalyzer.ts
@@ -14,4 +14,10 @@ export interface IScopeAnalyzer extends IAnalyzer<[ESTree.Node], void> {
      * @returns {Scope}
      */
     acquireScope(node: ESTree.Node): eslintScope.Scope;
+
+    /**
+     * @param {Node} node
+     * @returns {boolean}
+     */
+    isAnalyzed(node: ESTree.Node): boolean;
 }

--- a/src/interfaces/node-transformers/INodeTransformer.ts
+++ b/src/interfaces/node-transformers/INodeTransformer.ts
@@ -9,6 +9,11 @@ import { NodeTransformationStage } from '../../enums/node-transformers/NodeTrans
 
 export interface INodeTransformer extends ITransformer<NodeTransformer> {
     /**
+     * @type {boolean}
+     */
+    runOnProgramNodeOnly?: boolean;
+
+    /**
      * @param {NodeTransformationStage} nodeTransformationStage
      * @returns {IVisitor | null}
      */

--- a/src/interfaces/node/IScopeIdentifiersTraverser.ts
+++ b/src/interfaces/node/IScopeIdentifiersTraverser.ts
@@ -7,23 +7,23 @@ import { IScopeThroughIdentifiersTraverserCallbackData } from './IScopeThroughId
 export interface IScopeIdentifiersTraverser {
     /**
      * @param {Program} programNode
-     * @param {Node | null} parentNode
      * @param {TScopeIdentifiersTraverserCallback<IScopeIdentifiersTraverserCallbackData>} callback
+     * @param {boolean} analyzeScope
      */
     traverseScopeIdentifiers(
         programNode: ESTree.Program,
-        parentNode: ESTree.Node | null,
-        callback: TScopeIdentifiersTraverserCallback<IScopeIdentifiersTraverserCallbackData>
+        callback: TScopeIdentifiersTraverserCallback<IScopeIdentifiersTraverserCallbackData>,
+        analyzeScope?: boolean
     ): void;
 
     /**
      * @param {Node} node
-     * @param {Node | null} parentNode
      * @param {TScopeIdentifiersTraverserCallback<IScopeThroughIdentifiersTraverserCallbackData>} callback
+     * @param {boolean} analyzeScope
      */
     traverseScopeThroughIdentifiers(
         node: ESTree.Node,
-        parentNode: ESTree.Node | null,
-        callback: TScopeIdentifiersTraverserCallback<IScopeThroughIdentifiersTraverserCallbackData>
+        callback: TScopeIdentifiersTraverserCallback<IScopeThroughIdentifiersTraverserCallbackData>,
+        analyzeScope?: boolean
     ): void;
 }

--- a/src/node-transformers/AbstractNodeTransformer.ts
+++ b/src/node-transformers/AbstractNodeTransformer.ts
@@ -20,6 +20,11 @@ export abstract class AbstractNodeTransformer implements INodeTransformer {
     public readonly runAfter: NodeTransformer[] | undefined;
 
     /**
+     * @type {boolean}
+     */
+    public readonly runOnProgramNodeOnly: boolean | undefined;
+
+    /**
      * @type {IOptions}
      */
     protected readonly options: IOptions;

--- a/src/node-transformers/NodeTransformersRunner.ts
+++ b/src/node-transformers/NodeTransformersRunner.ts
@@ -23,6 +23,12 @@ import { VisitorDirection } from '../enums/node-transformers/VisitorDirection';
 import { NodeGuards } from '../node/NodeGuards';
 import { NodeMetadata } from '../node/NodeMetadata';
 
+interface IVisitorsData {
+    enterVisitors: IVisitor[];
+    leaveVisitors: IVisitor[];
+    runOnProgramNodeOnly: boolean;
+}
+
 @injectable()
 export class NodeTransformersRunner implements INodeTransformersRunner {
     /**
@@ -75,27 +81,20 @@ export class NodeTransformersRunner implements INodeTransformersRunner {
             this.nodeTransformerNamesGroupsBuilder.build(normalizedNodeTransformers);
 
         for (const nodeTransformerNamesGroup of nodeTransformerNamesGroups) {
-            const enterVisitors: IVisitor[] = [];
-            const leaveVisitors: IVisitor[] = [];
-
-            for (const nodeTransformerName of nodeTransformerNamesGroup) {
-                const nodeTransformer: INodeTransformer = normalizedNodeTransformers[nodeTransformerName];
-                const visitor: IVisitor | null = nodeTransformer.getVisitor(nodeTransformationStage);
-
-                if (!visitor) {
-                    continue;
-                }
-
-                if (visitor.enter) {
-                    enterVisitors.push({ enter: visitor.enter });
-                }
-
-                if (visitor.leave) {
-                    leaveVisitors.push({ leave: visitor.leave });
-                }
-            }
+            const visitorsData: IVisitorsData = this.buildVisitorsData(
+                nodeTransformerNamesGroup,
+                normalizedNodeTransformers,
+                nodeTransformationStage
+            );
+            const { enterVisitors, leaveVisitors } = visitorsData;
 
             if (!enterVisitors.length && !leaveVisitors.length) {
+                continue;
+            }
+
+            if (this.canRunOnProgramNodeOnly(visitorsData, astTree)) {
+                astTree = this.runOnProgramNodeOnly(astTree, enterVisitors);
+
                 continue;
             }
 
@@ -106,6 +105,72 @@ export class NodeTransformersRunner implements INodeTransformersRunner {
         }
 
         return astTree;
+    }
+
+    /**
+     * @param {NodeTransformer[]} nodeTransformerNamesGroup
+     * @param {TDictionary<INodeTransformer>} normalizedNodeTransformers
+     * @param {NodeTransformationStage} nodeTransformationStage
+     * @returns {IVisitorsData}
+     */
+    private buildVisitorsData(
+        nodeTransformerNamesGroup: NodeTransformer[],
+        normalizedNodeTransformers: TDictionary<INodeTransformer>,
+        nodeTransformationStage: NodeTransformationStage
+    ): IVisitorsData {
+        const enterVisitors: IVisitor[] = [];
+        const leaveVisitors: IVisitor[] = [];
+        let runOnProgramNodeOnly: boolean = true;
+
+        for (const nodeTransformerName of nodeTransformerNamesGroup) {
+            const nodeTransformer: INodeTransformer = normalizedNodeTransformers[nodeTransformerName];
+            const visitor: IVisitor | null = nodeTransformer.getVisitor(nodeTransformationStage);
+
+            if (!visitor) {
+                continue;
+            }
+
+            if (!nodeTransformer.runOnProgramNodeOnly) {
+                runOnProgramNodeOnly = false;
+            }
+
+            if (visitor.enter) {
+                enterVisitors.push({ enter: visitor.enter });
+            }
+
+            if (visitor.leave) {
+                leaveVisitors.push({ leave: visitor.leave });
+            }
+        }
+
+        return { enterVisitors, leaveVisitors, runOnProgramNodeOnly };
+    }
+
+    /**
+     * @param {IVisitorsData} visitorsData
+     * @param {Node} astTree
+     * @returns {boolean}
+     */
+    private canRunOnProgramNodeOnly(visitorsData: IVisitorsData, astTree: ESTree.Node): boolean {
+        return (
+            visitorsData.runOnProgramNodeOnly &&
+            !visitorsData.leaveVisitors.length &&
+            NodeGuards.isProgramNode(astTree)
+        );
+    }
+
+    /**
+     * @param {T} astTree
+     * @param {IVisitor[]} enterVisitors
+     * @returns {T}
+     */
+    private runOnProgramNodeOnly<T extends ESTree.Node>(astTree: T, enterVisitors: IVisitor[]): T {
+        const visitorResult: TVisitorResult = this.mergeVisitorsForDirection(
+            enterVisitors,
+            VisitorDirection.Enter
+        )(astTree, astTree.parentNode ?? null);
+
+        return visitorResult && NodeGuards.isNode(visitorResult) ? <T>visitorResult : astTree;
     }
 
     /**

--- a/src/node-transformers/dead-code-injection-transformers/DeadCodeInjectionIdentifiersTransformer.ts
+++ b/src/node-transformers/dead-code-injection-transformers/DeadCodeInjectionIdentifiersTransformer.ts
@@ -62,7 +62,7 @@ export class DeadCodeInjectionIdentifiersTransformer extends AbstractNodeTransfo
                 return {
                     enter: (node: ESTree.Node, parentNode: ESTree.Node | null): ESTree.Node | undefined => {
                         if (parentNode && NodeGuards.isProgramNode(node)) {
-                            return this.transformNode(node, parentNode);
+                            return this.transformNode(node);
                         }
                     }
                 };
@@ -74,13 +74,11 @@ export class DeadCodeInjectionIdentifiersTransformer extends AbstractNodeTransfo
 
     /**
      * @param {VariableDeclaration} programNode
-     * @param {NodeGuards} parentNode
      * @returns {NodeGuards}
      */
-    public transformNode(programNode: ESTree.Program, parentNode: ESTree.Node): ESTree.Node {
+    public transformNode(programNode: ESTree.Program): ESTree.Node {
         this.scopeIdentifiersTraverser.traverseScopeThroughIdentifiers(
             programNode,
-            parentNode,
             (data: IScopeThroughIdentifiersTraverserCallbackData) => {
                 const { reference, variableLexicalScopeNode } = data;
 

--- a/src/node-transformers/preparing-transformers/VariablePreserveTransformer.ts
+++ b/src/node-transformers/preparing-transformers/VariablePreserveTransformer.ts
@@ -30,6 +30,11 @@ export class VariablePreserveTransformer extends AbstractNodeTransformer {
     public override readonly runAfter: NodeTransformer[] = [NodeTransformer.ParentificationTransformer];
 
     /**
+     * @type {boolean}
+     */
+    public override readonly runOnProgramNodeOnly: boolean = true;
+
+    /**
      * @type {IIdentifierReplacer}
      */
     private readonly identifierReplacer: IIdentifierReplacer;
@@ -64,17 +69,21 @@ export class VariablePreserveTransformer extends AbstractNodeTransformer {
      * @returns {IVisitor | null}
      */
     public getVisitor(nodeTransformationStage: NodeTransformationStage): IVisitor | null {
+        const visitor: IVisitor = {
+            enter: (node: ESTree.Node, parentNode: ESTree.Node | null): ESTree.Node | undefined => {
+                if (parentNode && NodeGuards.isProgramNode(node)) {
+                    return this.transformNode(node);
+                }
+            }
+        };
+
         switch (nodeTransformationStage) {
             case NodeTransformationStage.Preparing:
-            case NodeTransformationStage.Converting:
             case NodeTransformationStage.RenameIdentifiers:
-                return {
-                    enter: (node: ESTree.Node, parentNode: ESTree.Node | null): ESTree.Node | undefined => {
-                        if (parentNode && NodeGuards.isProgramNode(node)) {
-                            return this.transformNode(node, parentNode);
-                        }
-                    }
-                };
+                return visitor;
+
+            case NodeTransformationStage.Converting:
+                return this.shouldPreserveConvertingStageIdentifiers() ? visitor : null;
 
             default:
                 return null;
@@ -83,13 +92,11 @@ export class VariablePreserveTransformer extends AbstractNodeTransformer {
 
     /**
      * @param {VariableDeclaration} programNode
-     * @param {NodeGuards} parentNode
      * @returns {NodeGuards}
      */
-    public transformNode(programNode: ESTree.Program, parentNode: ESTree.Node): ESTree.Node {
+    public transformNode(programNode: ESTree.Program): ESTree.Node {
         this.scopeIdentifiersTraverser.traverseScopeIdentifiers(
             programNode,
-            parentNode,
             this.preserveScopeVariableIdentifiers
         );
 
@@ -135,5 +142,17 @@ export class VariablePreserveTransformer extends AbstractNodeTransformer {
         }
 
         this.identifierReplacer.preserveNameForLexicalScope(identifierNode, lexicalScopeNode);
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    private shouldPreserveConvertingStageIdentifiers(): boolean {
+        return (
+            this.options.controlFlowFlattening ||
+            this.options.deadCodeInjection ||
+            this.options.stringArray ||
+            this.options.transformObjectKeys
+        );
     }
 }

--- a/src/node-transformers/rename-identifiers-transformers/ScopeIdentifiersTransformer.ts
+++ b/src/node-transformers/rename-identifiers-transformers/ScopeIdentifiersTransformer.ts
@@ -15,6 +15,7 @@ import { IScopeIdentifiersTraverserCallbackData } from '../../interfaces/node/IS
 import { IVisitor } from '../../interfaces/node-transformers/IVisitor';
 
 import { NodeTransformationStage } from '../../enums/node-transformers/NodeTransformationStage';
+import { NodeTransformer } from '../../enums/node-transformers/NodeTransformer';
 
 import { AbstractNodeTransformer } from '../AbstractNodeTransformer';
 import { NodeGuards } from '../../node/NodeGuards';
@@ -26,6 +27,16 @@ import { NodeMetadata } from '../../node/NodeMetadata';
 @injectFromBase()
 @injectable()
 export class ScopeIdentifiersTransformer extends AbstractNodeTransformer {
+    /**
+     * @type {NodeTransformer[]}
+     */
+    public override readonly runAfter: NodeTransformer[] = [NodeTransformer.VariablePreserveTransformer];
+
+    /**
+     * @type {boolean}
+     */
+    public override readonly runOnProgramNodeOnly: boolean = true;
+
     /**
      * @type {IIdentifierReplacer}
      */
@@ -70,7 +81,7 @@ export class ScopeIdentifiersTransformer extends AbstractNodeTransformer {
                 return {
                     enter: (node: ESTree.Node, parentNode: ESTree.Node | null): ESTree.Node | undefined => {
                         if (parentNode && NodeGuards.isProgramNode(node)) {
-                            return this.transformNode(node, parentNode);
+                            return this.transformNode(node);
                         }
                     }
                 };
@@ -82,13 +93,11 @@ export class ScopeIdentifiersTransformer extends AbstractNodeTransformer {
 
     /**
      * @param {VariableDeclaration} programNode
-     * @param {NodeGuards} parentNode
      * @returns {NodeGuards}
      */
-    public transformNode(programNode: ESTree.Program, parentNode: ESTree.Node): ESTree.Node {
+    public transformNode(programNode: ESTree.Program): ESTree.Node {
         this.scopeIdentifiersTraverser.traverseScopeIdentifiers(
             programNode,
-            parentNode,
             (data: IScopeIdentifiersTraverserCallbackData) => {
                 const { isGlobalDeclaration, variable, variableLexicalScopeNode } = data;
 
@@ -105,7 +114,8 @@ export class ScopeIdentifiersTransformer extends AbstractNodeTransformer {
                 }
 
                 this.transformScopeVariableIdentifiers(variable, variableLexicalScopeNode, isGlobalDeclaration);
-            }
+            },
+            false
         );
 
         return programNode;

--- a/src/node-transformers/rename-identifiers-transformers/ScopeThroughIdentifiersTransformer.ts
+++ b/src/node-transformers/rename-identifiers-transformers/ScopeThroughIdentifiersTransformer.ts
@@ -14,6 +14,7 @@ import { IThroughIdentifierReplacer } from '../../interfaces/node-transformers/r
 import { IVisitor } from '../../interfaces/node-transformers/IVisitor';
 
 import { NodeTransformationStage } from '../../enums/node-transformers/NodeTransformationStage';
+import { NodeTransformer } from '../../enums/node-transformers/NodeTransformer';
 
 import { AbstractNodeTransformer } from '../AbstractNodeTransformer';
 import { NodeGuards } from '../../node/NodeGuards';
@@ -24,6 +25,16 @@ import { NodeGuards } from '../../node/NodeGuards';
 @injectFromBase()
 @injectable()
 export class ScopeThroughIdentifiersTransformer extends AbstractNodeTransformer {
+    /**
+     * @type {NodeTransformer[]}
+     */
+    public override readonly runAfter: NodeTransformer[] = [NodeTransformer.ScopeIdentifiersTransformer];
+
+    /**
+     * @type {boolean}
+     */
+    public override readonly runOnProgramNodeOnly: boolean = true;
+
     /**
      * @type {IScopeIdentifiersTraverser}
      */
@@ -62,7 +73,7 @@ export class ScopeThroughIdentifiersTransformer extends AbstractNodeTransformer 
                 return {
                     enter: (node: ESTree.Node, parentNode: ESTree.Node | null): ESTree.Node | undefined => {
                         if (parentNode && NodeGuards.isProgramNode(node)) {
-                            return this.transformNode(node, parentNode);
+                            return this.transformNode(node);
                         }
                     }
                 };
@@ -74,18 +85,17 @@ export class ScopeThroughIdentifiersTransformer extends AbstractNodeTransformer 
 
     /**
      * @param {VariableDeclaration} programNode
-     * @param {NodeGuards} parentNode
      * @returns {NodeGuards}
      */
-    public transformNode(programNode: ESTree.Program, parentNode: ESTree.Node): ESTree.Node {
+    public transformNode(programNode: ESTree.Program): ESTree.Node {
         this.scopeIdentifiersTraverser.traverseScopeThroughIdentifiers(
             programNode,
-            parentNode,
             (data: IScopeThroughIdentifiersTraverserCallbackData) => {
                 const { reference, variableLexicalScopeNode } = data;
 
                 this.transformScopeThroughIdentifiers(reference, variableLexicalScopeNode);
-            }
+            },
+            false
         );
 
         return programNode;

--- a/src/node/ScopeIdentifiersTraverser.ts
+++ b/src/node/ScopeIdentifiersTraverser.ts
@@ -43,34 +43,28 @@ export class ScopeIdentifiersTraverser implements IScopeIdentifiersTraverser {
 
     /**
      * @param {Program} programNode
-     * @param {Node | null} parentNode
      * @param {TScopeIdentifiersTraverserCallback<IScopeIdentifiersTraverserCallbackData>} callback
      */
     public traverseScopeIdentifiers(
         programNode: ESTree.Program,
-        parentNode: ESTree.Node | null,
-        callback: TScopeIdentifiersTraverserCallback<IScopeIdentifiersTraverserCallbackData>
+        callback: TScopeIdentifiersTraverserCallback<IScopeIdentifiersTraverserCallbackData>,
+        analyzeScope: boolean = true
     ): void {
-        this.scopeAnalyzer.analyze(programNode);
-
-        const globalScope: eslintScope.Scope = this.scopeAnalyzer.acquireScope(programNode);
+        const globalScope: eslintScope.Scope = this.acquireGlobalScope(programNode, analyzeScope);
 
         this.traverseScopeIdentifiersRecursive(globalScope, globalScope, callback);
     }
 
     /**
      * @param {Program} programNode
-     * @param {Node | null} parentNode
      * @param {TScopeIdentifiersTraverserCallback<IScopeThroughIdentifiersTraverserCallbackData>} callback
      */
     public traverseScopeThroughIdentifiers(
         programNode: ESTree.Program,
-        parentNode: ESTree.Node | null,
-        callback: TScopeIdentifiersTraverserCallback<IScopeThroughIdentifiersTraverserCallbackData>
+        callback: TScopeIdentifiersTraverserCallback<IScopeThroughIdentifiersTraverserCallbackData>,
+        analyzeScope: boolean = true
     ): void {
-        this.scopeAnalyzer.analyze(programNode);
-
-        const globalScope: eslintScope.Scope = this.scopeAnalyzer.acquireScope(programNode);
+        const globalScope: eslintScope.Scope = this.acquireGlobalScope(programNode, analyzeScope);
 
         this.traverseScopeThroughIdentifiersRecursive(globalScope, globalScope, callback);
     }
@@ -157,5 +151,18 @@ export class ScopeIdentifiersTraverser implements IScopeIdentifiersTraverser {
         for (const childScope of currentScope.childScopes) {
             this.traverseScopeThroughIdentifiersRecursive(rootScope, childScope, callback);
         }
+    }
+
+    /**
+     * @param {Program} programNode
+     * @param {boolean} analyzeScope
+     * @returns {Scope}
+     */
+    private acquireGlobalScope(programNode: ESTree.Program, analyzeScope: boolean): eslintScope.Scope {
+        if (analyzeScope || !this.scopeAnalyzer.isAnalyzed(programNode)) {
+            this.scopeAnalyzer.analyze(programNode);
+        }
+
+        return this.scopeAnalyzer.acquireScope(programNode);
     }
 }


### PR DESCRIPTION
## Summary

Optimize identifier renaming performance by reusing scope analysis between transformers.

_Disclosure: developed with AI assistance._

## Details

The identifier renaming pipeline previously analyzed the same AST scope graph multiple times during one obfuscation run. For large bundles, `eslint-scope` became a significant part of total obfuscation time even after the scope-level caching added in #1417.

This change reduces redundant work by:

* reusing the scope analysis produced by `VariablePreserveTransformer` in `ScopeIdentifiersTransformer`;
* reusing the same scope analysis again in `ScopeThroughIdentifiersTransformer`;
* making scope sanitization run only once per `ScopeManager`;
* skipping the `Converting` stage preservation pass when enabled options cannot introduce generated identifier conflicts;
* adding a root-only transformer fast path to avoid full AST traversal for transformers that only handle `Program`;
* keeping a fallback analysis path for internal helper pipelines that do not have a reusable scope graph.

No output behavior is intended to change.

## Performance

Measured on identical, already-prepared large bundle input.

Compared to the current post-#1417 baseline:

| Format | Before | After |
|--------|--------|-------|
| ESM    | 5.63s  | 3.84s |
| UMD    | 5.12s  | 3.49s |

The number of main-pipeline scope analyzes for this configuration dropped from `5` to `2`.
