### PR TITLE
Fixed `SyntaxError` when obfuscating a class that extends a boolean literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 
+v5.4.5
+---
+* Fixed `SyntaxError` when obfuscating a class that extends a boolean literal (e.g. `class C extends true {}`). Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1131
+
 v5.4.4
 ---
 * Fixed `Invalid regular expression` error when obfuscating code that uses ES2025 RegExp pattern modifiers (e.g. `/(?i:abc)/`). Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1410

--- a/src/node-transformers/converting-transformers/BooleanLiteralTransformer.ts
+++ b/src/node-transformers/converting-transformers/BooleanLiteralTransformer.ts
@@ -66,6 +66,15 @@ export class BooleanLiteralTransformer extends AbstractNodeTransformer {
             return literalNode;
         }
 
+        /**
+         * A class heritage (`extends`) must be a `LeftHandSideExpression`, so replacing a
+         * boolean literal there with a unary expression (`class Foo extends ![] {}`) would
+         * produce a `SyntaxError`. Keep the original literal in that position.
+         */
+        if ('superClass' in parentNode && parentNode.superClass === literalNode) {
+            return literalNode;
+        }
+
         const literalValue: ESTree.SimpleLiteral['value'] = literalNode.value;
 
         const unaryExpressionNode: ESTree.UnaryExpression = literalValue

--- a/test/functional-tests/node-transformers/converting-transformers/boolean-literal-transformer/BooleanLiteralTransformer.spec.ts
+++ b/test/functional-tests/node-transformers/converting-transformers/boolean-literal-transformer/BooleanLiteralTransformer.spec.ts
@@ -46,4 +46,22 @@ describe('BooleanLiteralTransformer', () => {
             assert.match(obfuscatedCode, regExp);
         });
     });
+
+    describe('boolean literal as a class super class', () => {
+        const regExp: RegExp = /^class Foo extends true *{}$/;
+
+        let obfuscatedCode: string;
+
+        before(() => {
+            const code: string = readFileAsString(__dirname + '/fixtures/super-class-value.js');
+
+            obfuscatedCode = JavaScriptObfuscator.obfuscate(code, {
+                ...NO_ADDITIONAL_NODES_PRESET
+            }).getObfuscatedCode();
+        });
+
+        it('should not transform a boolean literal used as a class heritage to avoid a `SyntaxError`', () => {
+            assert.match(obfuscatedCode, regExp);
+        });
+    });
 });

--- a/test/functional-tests/node-transformers/converting-transformers/boolean-literal-transformer/fixtures/super-class-value.js
+++ b/test/functional-tests/node-transformers/converting-transformers/boolean-literal-transformer/fixtures/super-class-value.js
@@ -1,0 +1,1 @@
+class Foo extends true {}


### PR DESCRIPTION
`class C extends true {}` is valid JavaScript, but `BooleanLiteralTransformer` rewrote `true`/`false` into `!![]`/`![]` even in the `extends` position, emitting `class C extends ![] {}`. A class heritage must be a `LeftHandSideExpression`, so that causes an early `SyntaxError`. I skip the transformation when the literal is the class `superClass` and leave it unchanged; booleans everywhere else are still transformed as before. Added a regression test (it fails without the fix and passes with it).

Fixes #1131