### PR TITLE
Fixed `sourceMapFileName` ending in `.js.map` (e.g. `foo.min.js.map`) being mangled in the emitted `//# sourceMappingURL=` comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 
+v5.4.7
+---
+* Fixed `sourceMapFileName` ending in `.js.map` (e.g. `foo.min.js.map`) being mangled in the emitted `//# sourceMappingURL=` comment. Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1312
+
 v5.4.6
 ---
 * Fixed unicode (`\uXXXX`, `\u{XXXX}`) and hex (`\xXX`) escape sequences of string literals being un-escaped into their literal characters during obfuscation. Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/345

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-obfuscator",
-  "version": "5.4.6",
+  "version": "5.4.7",
   "description": "JavaScript obfuscator",
   "keywords": [
     "obfuscator",

--- a/src/options/normalizer-rules/SourceMapFileNameRule.ts
+++ b/src/options/normalizer-rules/SourceMapFileNameRule.ts
@@ -12,7 +12,19 @@ export const SourceMapFileNameRule: TOptionsNormalizerRule = (options: IOptions)
     let { sourceMapFileName }: { sourceMapFileName: string } = options;
 
     if (sourceMapFileName) {
-        sourceMapFileName = sourceMapFileName.replace(/^\/+/, '').replace(/(?:\.js)?(?:\.map)?$/, '');
+        sourceMapFileName = sourceMapFileName.replace(/^\/+/, '');
+
+        // a fully-qualified `*.js.map` file name is already in the canonical form, so it is kept as-is
+        // (otherwise the extension-stripping heuristic below would mangle names like `foo.min.js.map`)
+        // https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1312
+        if (sourceMapFileName.endsWith('.js.map')) {
+            return {
+                ...options,
+                sourceMapFileName
+            };
+        }
+
+        sourceMapFileName = sourceMapFileName.replace(/(?:\.js)?(?:\.map)?$/, '');
 
         let sourceMapFileNameParts: string[] = sourceMapFileName.split(StringSeparator.Dot);
         const sourceMapFileNamePartsCount: number = sourceMapFileNameParts.length;

--- a/test/functional-tests/issues/issue1312.spec.ts
+++ b/test/functional-tests/issues/issue1312.spec.ts
@@ -1,0 +1,52 @@
+import { assert } from 'chai';
+
+import { NO_ADDITIONAL_NODES_PRESET } from '../../../src/options/presets/NoCustomNodes';
+
+import { SourceMapMode } from '../../../src/enums/source-map/SourceMapMode';
+
+import { JavaScriptObfuscator } from '../../../src/JavaScriptObfuscatorFacade';
+
+//
+// https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1312
+//
+describe('Issue #1312', () => {
+    describe('`sourceMappingURL` should use the provided `sourceMapFileName`', () => {
+        describe('Variant #1: `*.min.js.map` file name', () => {
+            const sourceMappingUrlRegExp: RegExp = /\/\/# sourceMappingURL=a\.min\.js\.map$/;
+
+            let obfuscatedCode: string;
+
+            before(() => {
+                obfuscatedCode = JavaScriptObfuscator.obfuscate("console.log('Hello World');", {
+                    ...NO_ADDITIONAL_NODES_PRESET,
+                    sourceMap: true,
+                    sourceMapMode: SourceMapMode.Separate,
+                    sourceMapFileName: 'a.min.js.map'
+                }).getObfuscatedCode();
+            });
+
+            it('should keep the full `.js.map` file name in the `sourceMappingURL`', () => {
+                assert.match(obfuscatedCode, sourceMappingUrlRegExp);
+            });
+        });
+
+        describe('Variant #2: base name without extension still gets `.js.map`', () => {
+            const sourceMappingUrlRegExp: RegExp = /\/\/# sourceMappingURL=a\.js\.map$/;
+
+            let obfuscatedCode: string;
+
+            before(() => {
+                obfuscatedCode = JavaScriptObfuscator.obfuscate("console.log('Hello World');", {
+                    ...NO_ADDITIONAL_NODES_PRESET,
+                    sourceMap: true,
+                    sourceMapMode: SourceMapMode.Separate,
+                    sourceMapFileName: 'a'
+                }).getObfuscatedCode();
+            });
+
+            it('should append `.js.map` to a bare file name', () => {
+                assert.match(obfuscatedCode, sourceMappingUrlRegExp);
+            });
+        });
+    });
+});

--- a/test/functional-tests/options/OptionsNormalizer.spec.ts
+++ b/test/functional-tests/options/OptionsNormalizer.spec.ts
@@ -700,6 +700,48 @@ describe('OptionsNormalizer', () => {
                     assert.deepEqual(optionsPreset, expectedOptionsPreset);
                 });
             });
+
+            // https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1312
+            describe('Full `.js.map` file name is preserved as-is', () => {
+                before(() => {
+                    optionsPreset = getNormalizedOptions({
+                        ...getDefaultOptions(),
+                        sourceMapBaseUrl: 'http://localhost:9000',
+                        sourceMapFileName: 'outputSourceMapName.min.js.map'
+                    });
+
+                    expectedOptionsPreset = {
+                        ...getDefaultOptions(),
+                        sourceMapBaseUrl: 'http://localhost:9000/',
+                        sourceMapFileName: 'outputSourceMapName.min.js.map'
+                    };
+                });
+
+                it('should normalize options preset', () => {
+                    assert.deepEqual(optionsPreset, expectedOptionsPreset);
+                });
+            });
+
+            // https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1312
+            describe('Full `.js.map` file name with leading slashes', () => {
+                before(() => {
+                    optionsPreset = getNormalizedOptions({
+                        ...getDefaultOptions(),
+                        sourceMapBaseUrl: 'http://localhost:9000',
+                        sourceMapFileName: '//outputSourceMapName.min.js.map'
+                    });
+
+                    expectedOptionsPreset = {
+                        ...getDefaultOptions(),
+                        sourceMapBaseUrl: 'http://localhost:9000/',
+                        sourceMapFileName: 'outputSourceMapName.min.js.map'
+                    };
+                });
+
+                it('should normalize options preset', () => {
+                    assert.deepEqual(optionsPreset, expectedOptionsPreset);
+                });
+            });
         });
 
         describe('splitStringsChunkLengthRule', () => {


### PR DESCRIPTION
Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/1312