### PR TITLE
docs: pair the two npm-only command blocks in CLAUDE.md with their yarn form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,15 +475,23 @@ The project includes a browser build at `dist/index.browser.js` that can be used
 ```bash
 # Production build
 npm run build
+# or
+yarn run build
 
 # Development watch mode
 npm run watch
+# or
+yarn run watch
 
 # Build TypeScript typings
 npm run build:typings
+# or
+yarn run build:typings
 
 # Linting
 npm run eslint
+# or
+yarn run eslint
 ```
 
 ## Testing
@@ -1184,24 +1192,32 @@ The project uses **Husky** for git hooks:
 1. **Use watch mode during development**:
    ```bash
    npm run watch
+   # or
+   yarn run watch
    ```
    This rebuilds automatically when you save files.
 
 2. **Run specific tests during development**:
    ```bash
    npm run test:dev
+   # or
+   yarn run test:dev
    ```
    Faster than full test suite.
 
 3. **Check linting before committing**:
    ```bash
    npm run eslint
+   # or
+   yarn run eslint
    ```
    Fix issues before the pre-commit hook runs.
 
 4. **Test memory usage**:
    ```bash
    npm run test:mocha-memory-performance
+   # or
+   yarn run test:mocha-memory-performance
    ```
    Ensure your changes don't cause memory issues.
 
@@ -1209,6 +1225,9 @@ The project uses **Husky** for git hooks:
    ```bash
    npm run test:mocha-coverage
    npm run test:mocha-coverage:report
+   # or
+   yarn run test:mocha-coverage
+   yarn run test:mocha-coverage:report
    ```
    Check test coverage in the generated `coverage/` directory.
 


### PR DESCRIPTION
## What

CLAUDE.md consistently documents commands in an `npm run X` / `# or` / `yarn run X` paired style (e.g. "Quick Start" at ~L503, "Development Commands" at ~L1150) — but two sections fell out of that pattern and give npm-only commands: **"Build Scripts"** (~L473) and **"Development Tips"** (~L1182). This PR adds the missing `# or` / `yarn run X` lines to those two blocks, matching the file's own established style. Docs-only, purely additive, no existing line changed.

## Why it's worth a PR rather than a shrug

The repo's real package manager is unambiguous — `package.json` pins `"packageManager": "yarn@1.22.21"`, `yarn.lock` is the only lockfile, and CI runs `yarn install` / `yarn run build` — and most of CLAUDE.md handles that correctly by showing both forms. The wrinkle is file size: CLAUDE.md is ~45 KB, which is past the default 32 KB project-doc limit some agent runners apply (e.g. Codex's `project_doc_max_bytes`). A truncated reader gets cut off around line ~1000: it **does** see the npm-only "Build Scripts" block, but **never** reaches the later yarn-paired sections that would have corrected the impression. So the one block most likely to be an agent's only command reference is exactly the one teaching the un-pinned package manager. Adding the pairing where it's missing closes that gap without restructuring anything.

(That's also why this is framed as a consistency fix, not a "your docs are wrong" report — the file mostly does the right thing already.)

**Full disclosure:** we noticed this while validating [ai-harness-doctor](https://github.com/NieZhuZhu/ai-harness-doctor), a doc-drift linter we maintain — it flagged both the intra-file npm/yarn inconsistency and the 45 KB > 32 KB truncation risk; everything above is verifiable by eye from the cited lines. Measured impact of the broader defect class on another repo, for the curious: [benchmark & methodology](https://github.com/NieZhuZhu/ai-harness-doctor/tree/main/benchmark/corpus/evals/comp).

Out of scope, mentioned for completeness: the two "add your own script, then run it" tutorial snippets (~L740, ~L1055) are also npm-only, but they describe hypothetical scripts rather than existing repo commands, so they're left as-is — happy to pair those too if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
